### PR TITLE
Change default health check service port to 8765

### DIFF
--- a/holoscan/cli/packager/arguments.py
+++ b/holoscan/cli/packager/arguments.py
@@ -99,7 +99,7 @@ class PackagingArguments:
         if self.build_parameters.sdk == SdkType.Holoscan:
             self.application_manifest.readiness = {
                 "type": "command",
-                "command": ["/bin/grpc_health_probe", "-addr", ":8777"],
+                "command": ["/bin/grpc_health_probe", "-addr", ":8765"],
                 "initialDelaySeconds": 1,
                 "periodSeconds": 10,
                 "timeoutSeconds": 1,
@@ -107,7 +107,7 @@ class PackagingArguments:
             }
             self.application_manifest.liveness = {
                 "type": "command",
-                "command": ["/bin/grpc_health_probe", "-addr", ":8777"],
+                "command": ["/bin/grpc_health_probe", "-addr", ":8765"],
                 "initialDelaySeconds": 1,
                 "periodSeconds": 10,
                 "timeoutSeconds": 1,

--- a/holoscan/cli/packager/templates/Dockerfile.jinja2
+++ b/holoscan/cli/packager/templates/Dockerfile.jinja2
@@ -308,7 +308,7 @@ RUN curl -L -o /bin/grpc_health_probe {{ health_probe | pprint }} \
     && chmod +x /bin/grpc_health_probe && ls -l /bin/grpc_health_probe
 
 HEALTHCHECK --interval=10s --timeout=1s \
-    CMD /bin/grpc_health_probe -addr=:8777 || exit 1
+    CMD /bin/grpc_health_probe -addr=:8765 || exit 1
 
 # End install gRPC health probe
 {% endif %}

--- a/tests/unit/packager/test_arguments.py
+++ b/tests/unit/packager/test_arguments.py
@@ -159,7 +159,7 @@ class TestPackagingArguments:
         assert args.application_manifest.readiness["command"] == [
             "/bin/grpc_health_probe",
             "-addr",
-            ":8777",
+            ":8765",
         ]
         assert args.application_manifest.readiness["initialDelaySeconds"] == 1
         assert args.application_manifest.readiness["periodSeconds"] == 10
@@ -171,7 +171,7 @@ class TestPackagingArguments:
         assert args.application_manifest.liveness["command"] == [
             "/bin/grpc_health_probe",
             "-addr",
-            ":8777",
+            ":8765",
         ]
         assert args.application_manifest.liveness["initialDelaySeconds"] == 1
         assert args.application_manifest.liveness["periodSeconds"] == 10


### PR DESCRIPTION
In HSDK 2.9, the default health check service runs in the same port as the app driver on port 8765. 