### PR TITLE
Remove no-commit-to-branch to prevent failures on Github build

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,8 +45,6 @@ repos:
       - id: name-tests-test
         args: ["--pytest-test-first"]
         exclude: ^tests/app/.*
-      - id: no-commit-to-branch
-        args: [--branch, main]
       - id: requirements-txt-fixer
       - id: trailing-whitespace
 


### PR DESCRIPTION
This PR removes `no-commit-to-branch` from pre-commit check so the build would pass when running on the main branch on Github Actions.