### PR TITLE
Prompt when input directory is empty

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,11 +56,11 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]
-version = "0.0.0"
 
 # [tool.poetry.build]
 # script = "build.py"
 # generate-setup-file = false
+version = "0.0.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"

--- a/src/holoscan_cli/common/argparse_types.py
+++ b/src/holoscan_cli/common/argparse_types.py
@@ -84,10 +84,10 @@ def valid_existing_path(path: str) -> Path:
     path = os.path.expanduser(path)
     file_path = Path(path).absolute()
     if file_path.exists():
-        if os.path.isdir(file_path):
-            if os.listdir(file_path):
+        if file_path.is_dir():
+            if any(os.scandir(file_path)):
                 return file_path
-            raise argparse.ArgumentTypeError(f"No such file/folder: '{file_path}'")
+            raise argparse.ArgumentTypeError(f"Directory is empty: '{file_path}'")
         return file_path
     raise argparse.ArgumentTypeError(f"No such file/folder: '{file_path}'")
 

--- a/src/holoscan_cli/common/argparse_types.py
+++ b/src/holoscan_cli/common/argparse_types.py
@@ -84,6 +84,10 @@ def valid_existing_path(path: str) -> Path:
     path = os.path.expanduser(path)
     file_path = Path(path).absolute()
     if file_path.exists():
+        if os.path.isdir(file_path):
+            if os.listdir(path):
+                return file_path
+            raise argparse.ArgumentTypeError(f"No such file/folder: '{file_path}'")
         return file_path
     raise argparse.ArgumentTypeError(f"No such file/folder: '{file_path}'")
 

--- a/src/holoscan_cli/common/argparse_types.py
+++ b/src/holoscan_cli/common/argparse_types.py
@@ -85,7 +85,7 @@ def valid_existing_path(path: str) -> Path:
     file_path = Path(path).absolute()
     if file_path.exists():
         if os.path.isdir(file_path):
-            if os.listdir(path):
+            if os.listdir(file_path):
                 return file_path
             raise argparse.ArgumentTypeError(f"No such file/folder: '{file_path}'")
         return file_path

--- a/tests/unit/common/test_argparse_types.py
+++ b/tests/unit/common/test_argparse_types.py
@@ -93,6 +93,20 @@ class TestValidExistingPath:
         with pytest.raises(argparse.ArgumentTypeError):
             valid_existing_path("this/is/some/path")
 
+    def test_empty_directory(self, monkeypatch):
+        monkeypatch.setattr(pathlib.Path, "exists", lambda x: True)
+        monkeypatch.setattr(os.path, "isdir", lambda x: True)
+        monkeypatch.setattr(os, "listdir", lambda x: [])
+        with pytest.raises(argparse.ArgumentTypeError):
+            valid_existing_path("this/is/some/path")
+
+    def test_non_empty_directory(self, monkeypatch):
+        monkeypatch.setattr(pathlib.Path, "exists", lambda x: True)
+        monkeypatch.setattr(os.path, "isdir", lambda x: True)
+        monkeypatch.setattr(os, "listdir", lambda x: ["/a"])
+        result = valid_existing_path("this/is/some/path")
+        assert type(result) is PosixPath
+
 
 class TestValidPlatforms:
     @pytest.mark.parametrize(

--- a/tests/unit/common/test_argparse_types.py
+++ b/tests/unit/common/test_argparse_types.py
@@ -95,15 +95,15 @@ class TestValidExistingPath:
 
     def test_empty_directory(self, monkeypatch):
         monkeypatch.setattr(pathlib.Path, "exists", lambda x: True)
-        monkeypatch.setattr(os.path, "isdir", lambda x: True)
-        monkeypatch.setattr(os, "listdir", lambda x: [])
+        monkeypatch.setattr(pathlib.Path, "is_dir", lambda x: True)
+        monkeypatch.setattr(os, "scandir", lambda x: [])
         with pytest.raises(argparse.ArgumentTypeError):
             valid_existing_path("this/is/some/path")
 
     def test_non_empty_directory(self, monkeypatch):
         monkeypatch.setattr(pathlib.Path, "exists", lambda x: True)
-        monkeypatch.setattr(os.path, "isdir", lambda x: True)
-        monkeypatch.setattr(os, "listdir", lambda x: ["/a"])
+        monkeypatch.setattr(pathlib.Path, "is_dir", lambda x: True)
+        monkeypatch.setattr(os, "scandir", lambda x: ["file"])
         result = valid_existing_path("this/is/some/path")
         assert type(result) is PosixPath
 


### PR DESCRIPTION
Update the existing `valid_existing_path` function, used by argparse, to ensure that the directory is not empty when the path is a directory.

Added unit test to cover the changes.