### PR TITLE
HSDK 3.0.0 support

### DIFF
--- a/releases/3.0.0/artifacts.json
+++ b/releases/3.0.0/artifacts.json
@@ -1,0 +1,152 @@
+{
+  "3.0.0": {
+    "holoscan": {
+      "debian-version": "3.0.0.0-1",
+      "wheel-version": "3.0.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:12.6.0-runtime-ubuntu22.04",
+        "igpu": "nvcr.io/nvidia/tensorrt:24.08-py3-igpu"
+      },
+      "build-images": {
+        "igpu": {
+          "jetson-agx-orin-devkit": "nvcr.io/nvstaging/holoscan/holoscan:v3.0.0.0-igpu",
+          "igx-orin-devkit": "nvcr.io/nvstaging/holoscan/holoscan:v3.0.0.0-igpu",
+          "sbsa": "nvcr.io/nvstaging/holoscan/holoscan:v3.0.0.0-igpu"
+        },
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvstaging/holoscan/holoscan:v3.0.0.0-dgpu",
+          "igx-orin-devkit": "nvcr.io/nvstaging/holoscan/holoscan:v3.0.0.0-dgpu",
+          "sbsa": "nvcr.io/nvstaging/holoscan/holoscan:v3.0.0.0-dgpu",
+          "clara-agx-devkit": "nvcr.io/nvstaging/holoscan/holoscan:v3.0.0.0-dgpu"
+        },
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvstaging/holoscan/holoscan:v3.0.0.0-dgpu"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.19/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.19/grpc_health_probe-linux-arm64"
+    }
+  },
+  "2.9.0": {
+    "holoscan": {
+      "debian-version": "2.9.0.2-1",
+      "wheel-version": "2.9.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:12.6.0-runtime-ubuntu22.04",
+        "igpu": "nvcr.io/nvidia/tensorrt:24.08-py3-igpu"
+      },
+      "build-images": {
+        "igpu": {
+          "jetson-agx-orin-devkit": "nvcr.io/nvstaging/holoscan/holoscan:v3.0.0.0-igpu",
+          "igx-orin-devkit": "nvcr.io/nvstaging/holoscan/holoscan:v3.0.0.0-igpu",
+          "sbsa": "nvcr.io/nvstaging/holoscan/holoscan:v3.0.0.0-igpu"
+        },
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvstaging/holoscan/holoscan:v3.0.0.0-dgpu",
+          "igx-orin-devkit": "nvcr.io/nvstaging/holoscan/holoscan:v3.0.0.0-dgpu",
+          "sbsa": "nvcr.io/nvstaging/holoscan/holoscan:v3.0.0.0-dgpu",
+          "clara-agx-devkit": "nvcr.io/nvstaging/holoscan/holoscan:v3.0.0.0-dgpu"
+        },
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvstaging/holoscan/holoscan:v3.0.0.0-dgpu"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.19/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.19/grpc_health_probe-linux-arm64"
+    }
+  },
+  "2.8.0": {
+    "holoscan": {
+      "debian-version": "2.8.0.1-1",
+      "wheel-version": "2.8.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:12.6.0-runtime-ubuntu22.04",
+        "igpu": "nvcr.io/nvidia/tensorrt:24.08-py3-igpu"
+      },
+      "build-images": {
+        "igpu": {
+          "jetson-agx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v2.8.0-igpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v2.8.0-igpu",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v2.8.0-igpu"
+        },
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v2.8.0-dgpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v2.8.0-dgpu",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v2.8.0-dgpu",
+          "clara-agx-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v2.8.0-dgpu"
+        },
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v2.8.0-dgpu"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.19/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.19/grpc_health_probe-linux-arm64"
+    }
+  },
+  "2.7.0": {
+    "holoscan": {
+      "debian-version": "2.7.0.2-1",
+      "wheel-version": "2.7.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:12.6.0-runtime-ubuntu22.04",
+        "igpu": "nvcr.io/nvidia/tensorrt:24.08-py3-igpu"
+      },
+      "build-images": {
+        "igpu": {
+          "jetson-agx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v2.7.0-igpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v2.7.0-igpu",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v2.7.0-igpu"
+        },
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v2.7.0-dgpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v2.7.0-dgpu",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v2.7.0-dgpu",
+          "clara-agx-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v2.7.0-dgpu"
+        },
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v2.7.0-dgpu"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.19/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.19/grpc_health_probe-linux-arm64"
+    }
+  },
+  "2.6.0": {
+    "holoscan": {
+      "debian-version": "2.6.0.1-1",
+      "wheel-version": "2.6.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:12.6.0-runtime-ubuntu22.04",
+        "igpu": "nvcr.io/nvidia/tensorrt:24.08-py3-igpu"
+      },
+      "build-images": {
+        "igpu": {
+          "jetson-agx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v2.6.0-igpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v2.6.0-igpu",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v2.6.0-igpu"
+        },
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v2.6.0-dgpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v2.6.0-dgpu",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v2.6.0-dgpu",
+          "clara-agx-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v2.6.0-dgpu"
+        },
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v2.6.0-dgpu"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.19/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.19/grpc_health_probe-linux-arm64"
+    }
+  }
+}


### PR DESCRIPTION
Add Holoscan 3.0.0 artifacts.
Users may continue to use 2.9.0 wheel package  