### PR TITLE
Consolidate platform and platform-config into one

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -138,7 +138,7 @@ jobs:
           poetry run pip install --upgrade pip setuptools
           poetry install --with test
 
-      - name: Build Application
+      - name: Build and Install CLI
         run: |
           poetry build
           wheel=$(find dist/ -name holoscan_cli-*.whl)
@@ -160,7 +160,6 @@ jobs:
                             -t test-app-python \
                             --platform x64-workstation \
                             --sdk-version 0.0.0 \
-                            --holoscan-sdk-file $(find dist/ -name holoscan_cli-*-py3-none-linux_x86_64.whl) \
                             tests/app/python/
 
       - name: Run Test App

--- a/src/holoscan_cli/__main__.py
+++ b/src/holoscan_cli/__main__.py
@@ -20,7 +20,6 @@ import os
 from pathlib import Path
 from typing import Optional, Union
 
-from .common.enum_types import Platform, PlatformConfiguration
 
 logging.getLogger("docker.api.build").setLevel(logging.WARNING)
 logging.getLogger("docker.auth").setLevel(logging.WARNING)
@@ -96,14 +95,6 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     if args.command is None:
         parser.print_help()
         parser.exit()
-
-    if args.command == "package":
-        if args.platform[0] == Platform.X64Workstation:
-            args.platform_config = PlatformConfiguration.dGPU
-        elif args.platform_config is None:
-            parser.error(
-                f"'--platform-config' is required for '{args.platform[0].value}'"
-            )
 
     return args
 

--- a/src/holoscan_cli/common/constants.py
+++ b/src/holoscan_cli/common/constants.py
@@ -77,19 +77,22 @@ class SDK:
     """
 
     # Platform to architecture mappings
-    PLATFORM_MAPPINGS = {
-        Platform.IGXOrinDevIt: Arch.arm64,
-        Platform.JetsonAgxOrinDevKit: Arch.arm64,
+    PLATFORM_ARCH_MAPPINGS = {
+        Platform.Jetson: Arch.arm64,
+        Platform.IGX_iGPU: Arch.arm64,
+        Platform.IGX_dGPU: Arch.arm64,
         Platform.SBSA: Arch.arm64,
         Platform.X64Workstation: Arch.amd64,
+        Platform.x86_64: Arch.amd64,
     }
 
     # Values of all platforms supported by the Packager
     PLATFORMS = [
-        Platform.IGXOrinDevIt.value,
-        Platform.JetsonAgxOrinDevKit.value,
+        Platform.Jetson.value,
+        Platform.IGX_iGPU.value,
+        Platform.IGX_dGPU.value,
         Platform.SBSA.value,
-        Platform.X64Workstation.value,
+        Platform.x86_64.value,
     ]
 
     # Values of all platform configurations supported by the Packager
@@ -97,6 +100,14 @@ class SDK:
         PlatformConfiguration.iGPU.value,
         PlatformConfiguration.dGPU.value,
     ]
+
+    INTERNAL_PLATFORM_MAPPINGS = {
+        Platform.Jetson: (Platform.JetsonAgxOrinDevKit, PlatformConfiguration.iGPU),
+        Platform.IGX_iGPU: (Platform.IGXOrinDevIt, PlatformConfiguration.iGPU),
+        Platform.IGX_dGPU: (Platform.IGXOrinDevIt, PlatformConfiguration.dGPU),
+        Platform.SBSA: (Platform.SBSA, PlatformConfiguration.dGPU),
+        Platform.x86_64: (Platform.X64Workstation, PlatformConfiguration.dGPU),
+    }
 
     # Values of SDKs supported by the Packager
     SDKS = [SdkType.Holoscan.value, SdkType.MonaiDeploy.value]

--- a/src/holoscan_cli/common/constants.py
+++ b/src/holoscan_cli/common/constants.py
@@ -82,7 +82,6 @@ class SDK:
         Platform.IGX_iGPU: Arch.arm64,
         Platform.IGX_dGPU: Arch.arm64,
         Platform.SBSA: Arch.arm64,
-        Platform.X64Workstation: Arch.amd64,
         Platform.x86_64: Arch.amd64,
     }
 

--- a/src/holoscan_cli/common/enum_types.py
+++ b/src/holoscan_cli/common/enum_types.py
@@ -37,10 +37,17 @@ class Arch(Enum):
 
 
 class Platform(Enum):
+    # User values - update SDK.Platforms
+    Jetson = "jetson"
+    IGX_iGPU = "igx-igpu"
+    IGX_dGPU = "igx-dgpu"
+    SBSA = "sbsa"
+    x86_64 = "x86_64"
+
+    # Internal use only
     IGXOrinDevIt = "igx-orin-devkit"
     JetsonAgxOrinDevKit = "jetson-agx-orin-devkit"
     X64Workstation = "x64-workstation"
-    SBSA = "sbsa"
 
 
 class PlatformConfiguration(Enum):

--- a/src/holoscan_cli/common/enum_types.py
+++ b/src/holoscan_cli/common/enum_types.py
@@ -37,14 +37,15 @@ class Arch(Enum):
 
 
 class Platform(Enum):
-    # User values - update SDK.Platforms
+    # User values - when a new value is added, please also update SDK.PLATFORMS
     Jetson = "jetson"
     IGX_iGPU = "igx-igpu"
     IGX_dGPU = "igx-dgpu"
     SBSA = "sbsa"
     x86_64 = "x86_64"
 
-    # Internal use only
+    # Internal use only - for mapping actual platform with platform configuration
+    #  as defined in SDK.INTERNAL_PLATFORM_MAPPINGS.
     IGXOrinDevIt = "igx-orin-devkit"
     JetsonAgxOrinDevKit = "jetson-agx-orin-devkit"
     X64Workstation = "x64-workstation"

--- a/src/holoscan_cli/packager/arguments.py
+++ b/src/holoscan_cli/packager/arguments.py
@@ -127,7 +127,9 @@ class PackagingArguments:
                 self.build_parameters.monai_deploy_app_sdk_version
             )
 
-        self._package_manifest.platform_config = args.platform_config.value
+        self._package_manifest.platform_config = self._platforms[
+            0
+        ].platform_config.value
 
     def _read_application_config_file(self, config_file_path: Path):
         self._logger.info(

--- a/src/holoscan_cli/packager/package_command.py
+++ b/src/holoscan_cli/packager/package_command.py
@@ -22,7 +22,6 @@ from ..common.argparse_types import (
     valid_dir_path,
     valid_existing_dir_path,
     valid_existing_path,
-    valid_platform_config,
     valid_platforms,
     valid_sdk_type,
 )
@@ -69,12 +68,6 @@ def create_package_parser(
         required=True,
         help="target platform(s) for the build output separated by comma. "
         f"Valid values: {str.join(', ', SDK.PLATFORMS)}.",
-    )
-    parser.add_argument(
-        "--platform-config",
-        type=valid_platform_config,
-        help="target platform configuration for the build output. "
-        f"Valid values: {str.join(', ', SDK.PLATFORM_CONFIGS)}.",
     )
     parser.add_argument(
         "--add",

--- a/src/holoscan_cli/packager/parameters.py
+++ b/src/holoscan_cli/packager/parameters.py
@@ -34,14 +34,15 @@ class PlatformParameters:
     def __init__(
         self,
         platform: Platform,
-        platform_config: PlatformConfiguration,
         tag: str,
         version: str,
     ) -> None:
         self._logger = logging.getLogger("platform.parameters")
-        self._platform: Platform = platform
-        self._platform_config: PlatformConfiguration = platform_config
-        self._arch: Arch = SDK.PLATFORM_MAPPINGS[platform]
+        self._platform = SDK.INTERNAL_PLATFORM_MAPPINGS[platform][0]
+        self._platform_config: PlatformConfiguration = SDK.INTERNAL_PLATFORM_MAPPINGS[
+            platform
+        ][1]
+        self._arch: Arch = SDK.PLATFORM_ARCH_MAPPINGS[platform]
         self._tag_prefix: Optional[str]
         self._version: Optional[str]
 

--- a/src/holoscan_cli/packager/platforms.py
+++ b/src/holoscan_cli/packager/platforms.py
@@ -76,11 +76,7 @@ class Platform:
 
         platforms = []
         for platform in args.platform:
-            platform_config = args.platform_config
-
-            platform_parameters = PlatformParameters(
-                platform, platform_config, args.tag, version
-            )
+            platform_parameters = PlatformParameters(platform, args.tag, version)
 
             (
                 platform_parameters.custom_base_image,

--- a/tests/app/artifacts.json
+++ b/tests/app/artifacts.json
@@ -1,8 +1,8 @@
 {
   "0.0.0": {
     "holoscan": {
-      "debian-version": "0.0.0",
-      "wheel-version": "0.0.0",
+      "debian-version": "2.9.0.0-1",
+      "wheel-version": "2.9.0",
       "base-images": {
         "dgpu": "nvcr.io/nvidia/cuda:12.6.0-runtime-ubuntu22.04",
         "igpu": "nvcr.io/nvidia/tensorrt:24.08-py3-igpu"

--- a/tests/unit/common/test_argparse_types.py
+++ b/tests/unit/common/test_argparse_types.py
@@ -112,15 +112,17 @@ class TestValidPlatforms:
     @pytest.mark.parametrize(
         "platforms",
         [
-            ([Platform.IGXOrinDevIt]),
-            ([Platform.JetsonAgxOrinDevKit]),
-            ([Platform.X64Workstation]),
-            ([Platform.IGXOrinDevIt, Platform.X64Workstation]),
+            ([Platform.Jetson]),
+            ([Platform.IGX_dGPU]),
+            ([Platform.IGX_iGPU]),
+            ([Platform.SBSA]),
+            ([Platform.x86_64]),
+            ([Platform.SBSA, Platform.x86_64]),
             (
                 [
-                    Platform.IGXOrinDevIt,
-                    Platform.X64Workstation,
-                    Platform.JetsonAgxOrinDevKit,
+                    Platform.Jetson,
+                    Platform.IGX_dGPU,
+                    Platform.SBSA,
                 ]
             ),
         ],
@@ -136,7 +138,7 @@ class TestValidPlatforms:
         [
             ("bad-platform"),
             (f"{Platform.IGXOrinDevIt.value},bad-platform"),
-            (f"{Platform.IGXOrinDevIt.value},"),
+            (f"{Platform.IGX_iGPU.value},"),
         ],
     )
     def test_invalid_platforms(self, platforms: str):

--- a/tests/unit/common/test_artifact_source.py
+++ b/tests/unit/common/test_artifact_source.py
@@ -29,11 +29,6 @@ class TestArtifactSource:
         source_file_sample = current_file_path / "./artifacts.json"
         self._artifact_source.load(str(source_file_sample))
 
-    def test_loads_from_http(self):
-        artifact_source = ArtifactSources()
-        with pytest.raises(ManifestDownloadError):
-            artifact_source.load("http://holoscan")
-
     def test_loads_invalid_file(self, monkeypatch):
         monkeypatch.setattr(Path, "read_text", lambda x: "{}")
 
@@ -43,7 +38,7 @@ class TestArtifactSource:
         with pytest.raises(FileNotFoundError):
             artifact_sources.load(str(source_file_sample))
 
-    def test_loads_from_custom_url_with_error(self, monkeypatch):
+    def test_loads_from_https_with_error(self, monkeypatch):
         def mock_get(*args, **kwargs):
             response = requests.Response()
             response.status_code = 500
@@ -54,6 +49,18 @@ class TestArtifactSource:
         artifact_source = ArtifactSources()
         with pytest.raises(ManifestDownloadError):
             artifact_source.load("https://holoscan")
+
+    def test_loads_from_http_with_error(self, monkeypatch):
+        def mock_get(*args, **kwargs):
+            response = requests.Response()
+            response.status_code = 500
+            response.reason = "error"
+            return response
+
+        monkeypatch.setattr(requests, "get", mock_get)
+        artifact_source = ArtifactSources()
+        with pytest.raises(ManifestDownloadError):
+            artifact_source.load("http://holoscan")
 
     def test_debian_package_version(self):
         self._init()

--- a/tests/unit/packager/test_arguments.py
+++ b/tests/unit/packager/test_arguments.py
@@ -20,12 +20,12 @@ import pytest
 from holoscan_cli.common.enum_types import (
     ApplicationType,
     Platform,
-    PlatformConfiguration,
     SdkType,
 )
 from holoscan_cli.packager.arguments import PackagingArguments
 from holoscan_cli.packager.manifest_files import ApplicationManifest, PackageManifest
 from holoscan_cli.packager.parameters import DefaultValues
+from holoscan_cli.packager.platforms import PlatformParameters
 
 
 class TestPackagingArguments:
@@ -47,7 +47,6 @@ class TestPackagingArguments:
         self.input_args.cmake_args = "-DARG1=A -DARG2=B"
         self.input_args.source = pathlib.Path("/path/to/source.json")
         self.input_args.platform = Platform.X64Workstation
-        self.input_args.platform_config = PlatformConfiguration.dGPU
         self.input_args.includes = []
         self.input_args.additional_libs = [
             pathlib.Path("/path/to/lib"),
@@ -67,7 +66,7 @@ class TestPackagingArguments:
                 SdkType.Holoscan,
                 "HoloscanVersionNum",
                 "MonaiDeployVersionNum",
-                [],
+                [PlatformParameters(Platform.Jetson, "tag", "1.0")],
             ),
         )
         monkeypatch.setattr(
@@ -192,7 +191,7 @@ class TestPackagingArguments:
         assert args.application_manifest.liveness["timeoutSeconds"] == 1
         assert args.application_manifest.liveness["failureThreshold"] == 3
 
-        assert len(args.platforms) == 0
+        assert len(args.platforms) == 1
 
     def test_input_args_no_timeout(self, monkeypatch):
         self._setup_mocks(monkeypatch)
@@ -230,7 +229,7 @@ class TestPackagingArguments:
                 SdkType.MonaiDeploy,
                 "HoloscanVersionNum",
                 "MonaiDeployVersionNum",
-                [],
+                [PlatformParameters(Platform.x86_64, "tag", "2.0")],
             ),
         )
         args = PackagingArguments(self.input_args, pathlib.Path("/temp"))
@@ -238,4 +237,4 @@ class TestPackagingArguments:
         assert args.application_manifest.readiness is None
         assert args.application_manifest.liveness is None
 
-        assert len(args.platforms) == 0
+        assert len(args.platforms) == 1

--- a/tests/unit/packager/test_container_builder.py
+++ b/tests/unit/packager/test_container_builder.py
@@ -20,7 +20,7 @@ import tempfile
 
 import holoscan_cli.common.dockerutils
 import pytest
-from holoscan_cli.common.enum_types import Platform, PlatformConfiguration, SdkType
+from holoscan_cli.common.enum_types import Platform, SdkType
 from holoscan_cli.packager.container_builder import BuilderBase
 from holoscan_cli.packager.parameters import PackageBuildParameters
 from holoscan_cli.packager.platforms import PlatformParameters
@@ -59,9 +59,7 @@ class TestContainerBuilder:
         monkeypatch.setattr(shutil, "copy2", lambda src, dest: None)
         build_parameters = self._get_build_parameters()
         build_parameters.no_cache = no_cache
-        platform_parameters = PlatformParameters(
-            Platform.X64Workstation, PlatformConfiguration.dGPU, "image:tag", "1.0"
-        )
+        platform_parameters = PlatformParameters(Platform.x86_64, "image:tag", "1.0")
 
         try:
             with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/unit/packager/test_parameters.py
+++ b/tests/unit/packager/test_parameters.py
@@ -21,17 +21,24 @@ from holoscan_cli.common.constants import Constants, DefaultValues
 from holoscan_cli.common.enum_types import (
     ApplicationType,
     Platform,
-    PlatformConfiguration,
 )
 from holoscan_cli.common.exceptions import UnknownApplicationTypeError
 from holoscan_cli.packager.parameters import PackageBuildParameters, PlatformParameters
 
 
 class TestPlatformParameters:
-    def test_with_aarch64(self, monkeypatch):
+    @pytest.mark.parametrize(
+        "platform",
+        [
+            (Platform.Jetson),
+            (Platform.IGX_iGPU),
+            (Platform.IGX_dGPU),
+            (Platform.SBSA),
+        ],
+    )
+    def test_jetson(self, platform: Platform):
         build_parameters = PlatformParameters(
-            Platform.IGXOrinDevIt,
-            PlatformConfiguration.iGPU,
+            platform,
             "my-container-app",
             "1.2.3",
         )
@@ -41,8 +48,7 @@ class TestPlatformParameters:
 
     def test_with_x64(self, monkeypatch):
         build_parameters = PlatformParameters(
-            Platform.X64Workstation,
-            PlatformConfiguration.dGPU,
+            Platform.x86_64,
             "my-container-app",
             "1.2.3",
         )

--- a/tests/unit/packager/test_platforms.py
+++ b/tests/unit/packager/test_platforms.py
@@ -299,11 +299,11 @@ class TestPlatforms:
                 input_args, temp_dir, application_verison, ApplicationType.CppCMake
             )
 
+            assert len(platforms) == len(input_args.platform)
             for index, platform_parameters in enumerate(platforms):
                 assert sdk == sdk_type
                 assert hsdk_version == holoscan_version
                 assert md_version == monai_deploy_version
-                assert len(platforms) == len(input_args.platform)
 
                 input_platform = input_args.platform[index]
                 expected_platform = SDK.INTERNAL_PLATFORM_MAPPINGS[input_platform][0]


### PR DESCRIPTION
With the introduction of a new platform `sbsa` we are consolidating platform and platform-config for the CLI to the following:

- jetson
- igx-igpu
- igx-dgpu
- sbsa
- x86_64

To minimize changes while combining the two arguments, a new internal mapping is used to map the options listed above into the existing `platform` + `platform-config` combination. If we need to split the two again, we can remove this mapping with minimal changes.

Mapping of the new platform options to the existing combination:

* Jetson: JetsonAgxOrinDevKit + PlatformConfiguration.iGPU
* igx-igpu: Platform.IGXOrinDevIt + PlatformConfiguration.iGPU
* igx-dgpu: Platform.IGXOrinDevIt + PlatformConfiguration.dGPU
* sbsa: Platform.SBSA + PlatformConfiguration.dGPU
* x86_64: (Platform.X64Workstation + PlatformConfiguration.dGPU

```
--platform PLATFORM   target platform(s) for the build output separated by comma. Valid values: jetson, igx-igpu, igx-dgpu, sbsa, x86_64.
```