### PR TITLE
Enable test-app with nv-gha-runner

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 enabled: true
-additional_trustees:
-additional_vetters:
+additional_trustees: []
+additional_vetters: []
 auto_sync_draft: false
 auto_sync_ready: true

--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This Dockerfile is used to build the Docker image for the NVIDIA GitHub Runners.
+FROM nvcr.io/nvidia/cuda:12.6.0-runtime-ubuntu22.04
+
+# Install git and jq
+RUN apt-get update && apt-get install -y git jq
+
+# Install Docker
+RUN apt-get update && \
+    apt-get install -y ca-certificates curl && \
+    install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc && \
+    chmod a+r /etc/apt/keyrings/docker.asc && \
+    echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+    $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
+    tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -183,6 +183,13 @@ jobs:
           echo "Installing from ${wheel}"
           pip install ${wheel}
 
+      - name: Restore cached Build Cache
+        id: cache-build-cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.holoscan_build_cache
+          key: test-app-cache
+
       - name: Package Test App
         env:
           ARTIFACT_PATH: ${{ steps.latest_artifact_path.outputs.ARTIFACT_PATH }}
@@ -212,6 +219,13 @@ jobs:
           touch input/file1
           touch output/file2
           holoscan run --rm --uid 1000 --gid 1000 -r $(docker images | grep "test-app-python" | awk '{print $1":"$2}') -i input -o output
+
+      - name: Save Build Cache
+        id: cache-build-cache-save
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.holoscan_build_cache
+          key: test-app-cache
 
   testpypi-deploy:
     name: publish-test-pypi

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -113,7 +113,6 @@ jobs:
           file: tests/reports/.coverage.lcov
 
   test-app:
-    # runs-on: ${{ matrix.os }}
     runs-on: linux-amd64-gpu-l4-latest-1
     container:
       image: nvidia/cuda:12.8.1-runtime-ubuntu22.04

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -115,7 +115,7 @@ jobs:
   test-app:
     runs-on: linux-amd64-gpu-l4-latest-1
     container:
-      image: nvidia/cuda:12.8.1-runtime-ubuntu22.04
+      image: ghcr.io/nvidia-holoscan/holoscan-cli-build:cuda126-u2204
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
     strategy:
@@ -126,33 +126,17 @@ jobs:
       PYTHON_VERSION: ${{ matrix.python-version }}
 
     steps:
-      - name: Install Git & JQ
+      - name: Verify and configure Git
         run: |
-          apt-get update
-          apt-get install -y git jq
+          command -v git
+          command -v jq
+          command -v docker
           git --version
           jq --version
+          docker --version
           echo $(pwd)
           # Configure Git to handle the repository ownership
           git config --global --add safe.directory $(pwd)
-
-      - name: Install Docker
-        run: |
-          # Add Docker's official GPG key:
-          apt-get update
-          apt-get install -y ca-certificates curl
-          install -m 0755 -d /etc/apt/keyrings
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-          chmod a+r /etc/apt/keyrings/docker.asc
-
-          # Add the repository to Apt sources:
-          echo \
-            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-            $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
-            tee /etc/apt/sources.list.d/docker.list > /dev/null
-          apt-get update
-          apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-          docker --version
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -116,8 +116,6 @@ jobs:
     runs-on: linux-amd64-gpu-l4-latest-1
     container:
       image: ghcr.io/nvidia-holoscan/holoscan-cli-build:cuda126-u2204
-      env:
-        NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,9 +24,6 @@ name: Code Check
 
 on:
   push:
-    branches: ["main", "release/*"]
-  pull_request:
-    branches: ["main", "release/*"]
 
 jobs:
   pre-commit:
@@ -116,8 +113,12 @@ jobs:
           file: tests/reports/.coverage.lcov
 
   test-app:
-    if: false # disable until GPU supported nodes become available
-    runs-on: ${{ matrix.os }}
+    # runs-on: ${{ matrix.os }}
+    runs-on: linux-amd64-gpu-l4-latest-1
+    container:
+      image: nvidia/cuda:12.8.1-runtime-ubuntu22.04
+      env:
+        NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -126,6 +127,34 @@ jobs:
       PYTHON_VERSION: ${{ matrix.python-version }}
 
     steps:
+      - name: Install Git & JQ
+        run: |
+          apt-get update
+          apt-get install -y git jq
+          git --version
+          jq --version
+          echo $(pwd)
+          # Configure Git to handle the repository ownership
+          git config --global --add safe.directory $(pwd)
+
+      - name: Install Docker
+        run: |
+          # Add Docker's official GPG key:
+          apt-get update
+          apt-get install -y ca-certificates curl
+          install -m 0755 -d /etc/apt/keyrings
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+          chmod a+r /etc/apt/keyrings/docker.asc
+
+          # Add the repository to Apt sources:
+          echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+            $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
+            tee /etc/apt/sources.list.d/docker.list > /dev/null
+          apt-get update
+          apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+          docker --version
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -142,6 +171,12 @@ jobs:
           poetry run pip install --upgrade pip setuptools
           poetry install --with test
 
+      - name: Locate Latest Artifacts
+        id: latest_artifact_path
+        run: |
+          echo "ARTIFACT_PATH=$(find releases -type f | sort | tail -n 1)" >> $GITHUB_OUTPUT
+          echo "CLI_VERSION=$(jq -r 'keys | sort_by(split(".") | map(tonumber)) | reverse | first' releases/3.0.0/artifacts.json)" >> $GITHUB_OUTPUT
+
       - name: Build and Install CLI
         run: |
           poetry build
@@ -149,32 +184,35 @@ jobs:
           echo "Installing from ${wheel}"
           pip install ${wheel}
 
-      - name: Version Check
-        run: |
-          output=$(holoscan version | tail -1 | tr -s ' ' | cut -d' ' -f3)
-          expected=$(grep -m 1 version pyproject.toml | tr -s ' ' | tr -d '"' | tr -d "'" | cut -d' ' -f3)
-          echo "Expected version: ${expected}"
-          echo "  Actual version: "$output""
-          test "$output" = "$expected"
-
       - name: Package Test App
+        env:
+          ARTIFACT_PATH: ${{ steps.latest_artifact_path.outputs.ARTIFACT_PATH }}
+          CLI_VERSION: ${{ steps.latest_artifact_path.outputs.CLI_VERSION }}
         run: |
-          holoscan package --source tests/app/artifacts.json \
+          holoscan package tests/app/python/ \
+                            -l DEBUG \
                             -c tests/app/python/app.yaml \
                             -t test-app-python \
-                            --platform x64-workstation \
-                            --sdk-version 0.0.0 \
-                            tests/app/python/
+                            --platform x86_64 \
+                            --uid 1000 \
+                            --gid 1000 \
+                            --source ${{ env.ARTIFACT_PATH }} \
+                            --sdk-version ${{ env.CLI_VERSION }} \
+                            --add-host developer.download.nvidia.com:23.46.17.44 \
+                            --add-host security.ubuntu.com:91.189.91.81 \
+                            --add-host archive.ubuntu.com:91.189.91.82 \
+                            --add-host pypi.org:151.101.128.223 \
+                            --add-host edge.urm.nvidia.com:23.46.228.176 \
+                            --add-host www.mellanox.com:23.46.228.176 \
+                            --add-host files.pythonhosted.org:151.101.0.223
 
       - name: Run Test App
-        env:
-          HOLOSCAN_SKIP_NVIDIA_CTK_CHECK: true
         run: |
           mkdir input
           mkdir output
-          touch input/file
-          touch output/file
-          holoscan run -r $(docker images | grep "test-app-python" | awk '{print $1":"$2}') -i input -o output
+          touch input/file1
+          touch output/file2
+          holoscan run --rm --uid 1000 --gid 1000 -r $(docker images | grep "test-app-python" | awk '{print $1":"$2}') -i input -o output
 
   testpypi-deploy:
     name: publish-test-pypi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,14 +128,16 @@ format-jinja = """
         {%- else -%}
             {%- if 'rc' in env -%}
                 {{ serialize_pep440(base, stage="rc", revision=env["rc"] ) }}
-            {%- elif 'GITHUB_RUN_ID' in env -%}
-                {{ serialize_pep440(base, stage="rc", revision=env['GITHUB_RUN_ID']) }}
             {%- else -%}
                 {{ serialize_pep440(base, stage="rc", revision=distance) }}
             {%- endif -%}
         {%- endif -%}
     {%- else -%}
-        {{ serialize_pep440(base, stage="alpha", revision=distance) }}
+        {%- if 'GITHUB_RUN_ID' in env -%}
+            {{ serialize_pep440(base, stage="alpha", revision=env['GITHUB_RUN_ID']) }}
+        {%- else -%}
+            {{ serialize_pep440(base, stage="alpha", revision=distance) }}
+        {%- endif -%}
     {%- endif -%}
 """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,8 @@ format-jinja = """
         {%- else -%}
             {%- if 'rc' in env -%}
                 {{ serialize_pep440(base, stage="rc", revision=env["rc"] ) }}
+            {%- elif 'GITHUB_RUN_ID' in env -%}
+                {{ serialize_pep440(base, stage="rc", revision=env['GITHUB_RUN_ID']) }}
             {%- else -%}
                 {{ serialize_pep440(base, stage="rc", revision=distance) }}
             {%- endif -%}

--- a/src/holoscan_cli/common/argparse_types.py
+++ b/src/holoscan_cli/common/argparse_types.py
@@ -156,7 +156,7 @@ def valid_sdk_type(sdk_str: str) -> SdkType:
     return SdkType(sdk_str)
 
 
-def validate_host_ip(host_ip: str) -> str:
+def valid_host_ip(host_ip: str) -> str:
     """Helper type checking and type converting method for ArgumentParser.add_argument
     to convert check valid host:ip format.
 

--- a/src/holoscan_cli/common/argparse_types.py
+++ b/src/holoscan_cli/common/argparse_types.py
@@ -15,7 +15,6 @@
 import argparse
 import os
 from pathlib import Path
-
 from .constants import SDK
 from .enum_types import Platform, PlatformConfiguration, SdkType
 
@@ -155,3 +154,18 @@ def valid_sdk_type(sdk_str: str) -> SdkType:
         raise argparse.ArgumentTypeError(f"{sdk_str} is not a valid option for --sdk.")
 
     return SdkType(sdk_str)
+
+
+def validate_host_ip(host_ip: str) -> str:
+    """Helper type checking and type converting method for ArgumentParser.add_argument
+    to convert check valid host:ip format.
+
+    Args:
+        host_ip: host ip string
+    """
+
+    host, ip = host_ip.split(":")
+    if host == "" or ip == "":
+        raise argparse.ArgumentTypeError(f"Invalid valid for --add-host: '{host_ip}'")
+
+    return host_ip

--- a/src/holoscan_cli/packager/arguments.py
+++ b/src/holoscan_cli/packager/arguments.py
@@ -76,6 +76,7 @@ class PackagingArguments:
         self.build_parameters.cmake_args = args.cmake_args
         self.build_parameters.includes = args.includes
         self.build_parameters.additional_libs = args.additional_libs
+        self.build_parameters.add_hosts = args.add_hosts
 
         models = Models()
         platform = Platform(self._artifact_sources)

--- a/src/holoscan_cli/packager/package_command.py
+++ b/src/holoscan_cli/packager/package_command.py
@@ -19,7 +19,7 @@ from argparse import ArgumentParser, _SubParsersAction
 from packaging.version import Version
 
 from ..common.argparse_types import (
-    validate_host_ip,
+    valid_host_ip,
     valid_dir_path,
     valid_existing_dir_path,
     valid_existing_path,
@@ -89,7 +89,7 @@ def create_package_parser(
         "--add-host",
         action="append",
         dest="add_hosts",
-        type=validate_host_ip,
+        type=valid_host_ip,
         help="Add a custom host-to-IP mapping (format: host:ip).",
     )
     advanced_group.add_argument(

--- a/src/holoscan_cli/packager/package_command.py
+++ b/src/holoscan_cli/packager/package_command.py
@@ -19,6 +19,7 @@ from argparse import ArgumentParser, _SubParsersAction
 from packaging.version import Version
 
 from ..common.argparse_types import (
+    validate_host_ip,
     valid_dir_path,
     valid_existing_dir_path,
     valid_existing_path,
@@ -84,6 +85,13 @@ def create_package_parser(
     )
 
     advanced_group = parser.add_argument_group(title="advanced build options")
+    advanced_group.add_argument(
+        "--add-host",
+        action="append",
+        dest="add_hosts",
+        type=validate_host_ip,
+        help="Add a custom host-to-IP mapping (format: host:ip).",
+    )
     advanced_group.add_argument(
         "--base-image",
         type=str,

--- a/src/holoscan_cli/packager/packager.py
+++ b/src/holoscan_cli/packager/packager.py
@@ -103,7 +103,7 @@ def _package_application(args: Namespace):
                     f"""\nPlatform: {result.parameters.platform.value}/{result.parameters.platform_config.value}
     Status:     Succeeded
     Docker Tag: {result.docker_tag if result.docker_tag is not None else "N/A"}
-    Tarball:    {result.tarball_filenaem}"""  # noqa: E501
+    Tarball:    {result.tarball_filename}"""  # noqa: E501
                 )
             else:
                 print(

--- a/src/holoscan_cli/packager/parameters.py
+++ b/src/holoscan_cli/packager/parameters.py
@@ -16,7 +16,7 @@ import logging
 import os
 import platform
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 from ..common.constants import SDK, Constants, DefaultValues
 from ..common.dockerutils import parse_docker_image_name_and_tag
@@ -205,7 +205,7 @@ class PlatformBuildResults:
     def __init__(self, parameters: PlatformParameters):
         self._parameters = parameters
         self._docker_tag: Optional[str] = None
-        self._tarball_filenaem: Optional[str] = None
+        self._tarball_filename: Optional[str] = None
         self._succeeded = False
         self._error: Optional[str] = None
 
@@ -230,12 +230,12 @@ class PlatformBuildResults:
         self._docker_tag = value
 
     @property
-    def tarball_filenaem(self) -> Optional[str]:
-        return self._tarball_filenaem
+    def tarball_filename(self) -> Optional[str]:
+        return self._tarball_filename
 
-    @tarball_filenaem.setter
-    def tarball_filenaem(self, value: Optional[str]):
-        self._tarball_filenaem = value
+    @tarball_filename.setter
+    def tarball_filename(self, value: Optional[str]):
+        self._tarball_filename = value
 
     @property
     def succeeded(self) -> bool:
@@ -278,7 +278,7 @@ class PackageBuildParameters:
         self._data["cmake_args"] = ""
         self._data["includes"] = []
         self._data["additional_lib_paths"] = ""
-
+        self._data["add_hosts"] = []
         self._data["application_directory"] = None
         self._data["application_type"] = None
         self._data["application"] = None
@@ -528,6 +528,14 @@ class PackageBuildParameters:
     @monai_deploy_app_sdk_version.setter
     def monai_deploy_app_sdk_version(self, value: str):
         self._data["monai_deploy_app_sdk_version"] = value
+
+    @property
+    def add_hosts(self) -> List[str]:
+        return self._data["add_hosts"]
+
+    @add_hosts.setter
+    def add_hosts(self, value: List[str]):
+        self._data["add_hosts"] = value
 
     @property
     def includes(self) -> str:

--- a/src/holoscan_cli/runner/run_command.py
+++ b/src/holoscan_cli/runner/run_command.py
@@ -92,6 +92,14 @@ def create_run_parser(
         "between 10000 and 32767 that is not currently in use.",
     )
 
+    parser.add_argument(
+        "--rm",
+        dest="rm",
+        action="store_true",
+        default=False,
+        help="remove the container after it exits.",
+    )
+
     advanced_group = parser.add_argument_group(title="advanced run options")
 
     advanced_group.add_argument(

--- a/src/holoscan_cli/runner/runner.py
+++ b/src/holoscan_cli/runner/runner.py
@@ -121,6 +121,7 @@ def _run_app(args: Namespace, app_info: dict, pkg_info: dict):
     worker_address: Optional[str] = args.worker_address if args.worker_address else None
     render: bool = args.render
     user: str = f"{args.uid}:{args.gid}"
+    remove: bool = args.rm
     hostname: Optional[str] = "driver" if driver else None
     terminal: bool = args.terminal
     platform_config: str = pkg_info.get("platformConfig")
@@ -174,6 +175,7 @@ def _run_app(args: Namespace, app_info: dict, pkg_info: dict):
         platform_config,
         shared_memory_size,
         args.uid == 0,
+        remove,
     )
 
 
@@ -266,10 +268,7 @@ def _pkg_specific_dependency_verification(pkg_info: dict) -> bool:
     Returns:
         True if all dependencies are satisfied, otherwise False.
     """
-    if (
-        os.path.exists("/.dockerenv")
-        or os.environ.get("HOLOSCAN_SKIP_NVIDIA_CTK_CHECK") is not None
-    ):
+    if os.path.exists("/.dockerenv"):
         logger.info("--> Skipping nvidia-ctk check inside Docker...\n")
         return True
 

--- a/tests/unit/common/test_argparse_types.py
+++ b/tests/unit/common/test_argparse_types.py
@@ -25,6 +25,7 @@ from holoscan_cli.common.argparse_types import (
     valid_platform_config,
     valid_platforms,
     valid_sdk_type,
+    valid_host_ip,
 )
 from holoscan_cli.common.enum_types import Platform, PlatformConfiguration, SdkType
 
@@ -252,3 +253,65 @@ class TestValidSdkType:
     def test_valid_sdk_type_whitespace(self):
         result = valid_sdk_type(" holoscan ")
         assert result == SdkType.Holoscan
+
+
+class TestValidHostIp:
+    """Test cases for valid_host_ip function in argparse_types.py."""
+
+    def test_valid_host_ip(self) -> None:
+        """Test valid_host_ip with valid host:ip format."""
+        # Arrange
+        valid_inputs = [
+            "hostname:127.0.0.1",
+            "example.com:192.168.1.1",
+            "server-01:10.0.0.1",
+        ]
+
+        # Act & Assert
+        for host_ip in valid_inputs:
+            result = valid_host_ip(host_ip)
+            assert result == host_ip
+
+    def test_empty_host(self) -> None:
+        """Test valid_host_ip with empty host part."""
+        # Arrange
+        invalid_input = ":127.0.0.1"
+
+        # Act & Assert
+        with pytest.raises(argparse.ArgumentTypeError) as exc_info:
+            valid_host_ip(invalid_input)
+
+        assert "Invalid valid for --add-host" in str(exc_info.value)
+
+    def test_empty_ip(self) -> None:
+        """Test valid_host_ip with empty IP part."""
+        # Arrange
+        invalid_input = "hostname:"
+
+        # Act & Assert
+        with pytest.raises(argparse.ArgumentTypeError) as exc_info:
+            valid_host_ip(invalid_input)
+
+        assert "Invalid valid for --add-host" in str(exc_info.value)
+
+    def test_no_colon_separator(self) -> None:
+        """Test valid_host_ip with no colon separator."""
+        # Arrange
+        invalid_input = "hostname127.0.0.1"
+
+        # Act & Assert
+        with pytest.raises(ValueError) as exc_info:
+            valid_host_ip(invalid_input)
+
+        assert "not enough values to unpack" in str(exc_info.value)
+
+    def test_multiple_colons(self) -> None:
+        """Test valid_host_ip with multiple colons."""
+        # Arrange
+        invalid_input = "hostname:127.0.0.1:8080"
+
+        # Act & Assert
+        with pytest.raises(ValueError) as exc_info:
+            valid_host_ip(invalid_input)
+
+        assert "too many values to unpack" in str(exc_info.value)

--- a/tests/unit/common/test_dockerutils.py
+++ b/tests/unit/common/test_dockerutils.py
@@ -292,6 +292,7 @@ class TestDockerRun:
                         "shm_size": "1GB",
                     },
                 )()
+                self.state = type("State", (), {"exit_code": 0})()
 
             def start(self, attach=False, stream=False):
                 if stream:
@@ -372,6 +373,7 @@ class TestDockerRun:
             platform_config=PlatformConfiguration.dGPU.value,
             shared_memory_size="1GB",
             is_root=False,
+            remove=False,
         )
 
     def test_container_run_with_igpu(
@@ -415,6 +417,7 @@ class TestDockerRun:
             platform_config=PlatformConfiguration.iGPU.value,
             shared_memory_size="1GB",
             is_root=False,
+            remove=False,
         )
 
     def test_container_run_with_render(
@@ -467,6 +470,7 @@ class TestDockerRun:
             platform_config=PlatformConfiguration.dGPU.value,
             shared_memory_size="1GB",
             is_root=False,
+            remove=False,
         )
 
     def test_container_run_with_terminal(
@@ -510,6 +514,7 @@ class TestDockerRun:
             platform_config=PlatformConfiguration.dGPU.value,
             shared_memory_size="1GB",
             is_root=False,
+            remove=False,
         )
 
     def test_container_run_gpu_resource_error(
@@ -550,6 +555,7 @@ class TestDockerRun:
                 platform_config=PlatformConfiguration.dGPU.value,
                 shared_memory_size="1GB",
                 is_root=False,
+                remove=False,
             )
         assert "Available GPUs (1) are less than required (2)" in str(exc_info.value)
 
@@ -601,4 +607,5 @@ class TestDockerRun:
             platform_config=PlatformConfiguration.dGPU.value,
             shared_memory_size="1GB",
             is_root=False,
+            remove=False,
         )

--- a/tests/unit/packager/test_arguments.py
+++ b/tests/unit/packager/test_arguments.py
@@ -48,6 +48,7 @@ class TestPackagingArguments:
         self.input_args.source = pathlib.Path("/path/to/source.json")
         self.input_args.platform = Platform.X64Workstation
         self.input_args.includes = []
+        self.input_args.add_hosts = ["domain:ip", "domain2:ip2"]
         self.input_args.additional_libs = [
             pathlib.Path("/path/to/lib"),
             pathlib.Path("/path/to/so"),
@@ -166,7 +167,7 @@ class TestPackagingArguments:
         assert args.package_manifest is not None
         assert args.build_parameters.build_cache == self.input_args.build_cache
         assert args.build_parameters.cmake_args == self.input_args.cmake_args
-
+        assert args.build_parameters.add_hosts == self.input_args.add_hosts
         assert args.application_manifest.readiness is not None
         assert args.application_manifest.readiness["type"] == "command"
         assert args.application_manifest.readiness["command"] == [

--- a/tests/unit/packager/test_container_builder.py
+++ b/tests/unit/packager/test_container_builder.py
@@ -115,6 +115,7 @@ class TestContainerBuilder:
             parameters.sdk = SdkType.Holoscan
             parameters.models = None
             parameters.docs = None
+            parameters.add_hosts = ["domain:ip", "domain2:ip2"]
             return parameters
 
         def test_basic_module(
@@ -127,9 +128,43 @@ class TestContainerBuilder:
                     return False
                 return True
 
+            def build_docker_image(**build_args):
+                assert build_args["builder"] == "builder"
+                assert build_args["add_hosts"] == {"domain": "ip", "domain2": "ip2"}
+                assert build_args["builder"] == "builder"
+                assert build_args["cache"] is True
+                assert build_args["cache_from"] == [
+                    {"type": "local", "src": pathlib.Path("~/.holoscan_build_cache")}
+                ]
+                assert build_args["cache_to"] == {
+                    "type": "local",
+                    "dest": pathlib.Path("~/.holoscan_build_cache"),
+                }
+                assert isinstance(build_args["context_path"], str)
+                assert build_args["file"].endswith("/Dockerfile")
+                assert build_args["platforms"] == ["linux/amd64"]
+                assert build_args["progress"] == "auto"
+                assert build_args["pull"] is True
+                assert build_args["tags"] == [
+                    "image-x64-workstation-dgpu-linux-amd64:tag"
+                ]
+                assert build_args["load"] is True
+                assert build_args["build_args"] == {
+                    "UID": os.getuid(),
+                    "GID": os.getgid(),
+                    "UNAME": "holoscan",
+                    "GPU_TYPE": "dgpu",
+                }
+
             monkeypatch.setattr(os.path, "isfile", lambda x: True)
             monkeypatch.setattr(os.path, "isdir", lambda x: True)
             monkeypatch.setattr(os.path, "exists", mock_file_exists)
+
+            monkeypatch.setattr(
+                holoscan_cli.packager.container_builder,
+                "build_docker_image",
+                build_docker_image,
+            )
 
             build_parameters = self._get_build_parameters()
             platform_parameters = PlatformParameters(
@@ -176,6 +211,7 @@ class TestContainerBuilder:
             parameters.models = None
             parameters.docs = None
             parameters.tarball_output = pathlib.Path("/tarball/")
+            parameters.add_hosts = ["domain:ip"]
             return parameters
 
         def test_basic_file(
@@ -187,6 +223,34 @@ class TestContainerBuilder:
         ):
             """Test building a basic Python file application"""
 
+            def build_docker_image(**build_args):
+                assert build_args["builder"] == "builder"
+                assert build_args["add_hosts"] == {"domain": "ip"}
+                assert build_args["builder"] == "builder"
+                assert build_args["cache"] is True
+                assert build_args["cache_from"] == [
+                    {"type": "local", "src": pathlib.Path("~/.holoscan_build_cache")}
+                ]
+                assert build_args["cache_to"] == {
+                    "type": "local",
+                    "dest": pathlib.Path("~/.holoscan_build_cache"),
+                }
+                assert isinstance(build_args["context_path"], str)
+                assert build_args["file"].endswith("/Dockerfile")
+                assert build_args["platforms"] == ["linux/amd64"]
+                assert build_args["progress"] == "auto"
+                assert build_args["pull"] is True
+                assert build_args["tags"] == [
+                    "image-x64-workstation-dgpu-linux-amd64:tag"
+                ]
+                assert build_args["load"] is True
+                assert build_args["build_args"] == {
+                    "UID": os.getuid(),
+                    "GID": os.getgid(),
+                    "UNAME": "holoscan",
+                    "GPU_TYPE": "dgpu",
+                }
+
             def mock_file_exists(path):
                 if path == "/app/requirements.txt":
                     return False
@@ -195,6 +259,11 @@ class TestContainerBuilder:
             monkeypatch.setattr(os.path, "isfile", lambda x: True)
             monkeypatch.setattr(os.path, "isdir", lambda x: False)
             monkeypatch.setattr(os.path, "exists", lambda x: mock_file_exists)
+            monkeypatch.setattr(
+                holoscan_cli.packager.container_builder,
+                "build_docker_image",
+                build_docker_image,
+            )
 
             build_parameters = self._get_build_parameters()
             build_parameters.application = pathlib.Path("/app/script.py")
@@ -257,12 +326,47 @@ class TestContainerBuilder:
             parameters.models = None
             parameters.docs = None
             parameters.tarball_output = pathlib.Path("/tarball/")
+            parameters.add_hosts = ["domain:ip"]
             return parameters
 
         def test_basic_cpp_project(
             self, mock_fs_operations, mock_docker_operations, _fs_mocks, monkeypatch
         ):
             """Test building a basic C++ CMake project"""
+
+            def build_docker_image(**build_args):
+                assert build_args["builder"] == "builder"
+                assert build_args["add_hosts"] == {"domain": "ip"}
+                assert build_args["builder"] == "builder"
+                assert build_args["cache"] is True
+                assert build_args["cache_from"] == [
+                    {"type": "local", "src": pathlib.Path("~/.holoscan_build_cache")}
+                ]
+                assert build_args["cache_to"] == {
+                    "type": "local",
+                    "dest": pathlib.Path("~/.holoscan_build_cache"),
+                }
+                assert isinstance(build_args["context_path"], str)
+                assert build_args["file"].endswith("/Dockerfile")
+                assert build_args["platforms"] == ["linux/amd64"]
+                assert build_args["progress"] == "auto"
+                assert build_args["pull"] is True
+                assert build_args["tags"] == [
+                    "image-x64-workstation-dgpu-linux-amd64:tag"
+                ]
+                assert build_args["load"] is True
+                assert build_args["build_args"] == {
+                    "UID": os.getuid(),
+                    "GID": os.getgid(),
+                    "UNAME": "holoscan",
+                    "GPU_TYPE": "dgpu",
+                }
+
+            monkeypatch.setattr(
+                holoscan_cli.packager.container_builder,
+                "build_docker_image",
+                build_docker_image,
+            )
 
             build_parameters = self._get_build_parameters()
             platform_parameters = PlatformParameters(
@@ -315,6 +419,7 @@ class TestContainerBuilder:
             parameters.models = None
             parameters.docs = None
             parameters.tarball_output = pathlib.Path("/tarball/")
+            parameters.add_hosts = ["domain:ip"]
 
             assert parameters.application_type == ApplicationType.Binary
             return parameters
@@ -323,9 +428,43 @@ class TestContainerBuilder:
             self, mock_fs_operations, mock_docker_operations, monkeypatch
         ):
             """Test building a basic binary application"""
+
+            def build_docker_image(**build_args):
+                assert build_args["builder"] == "builder"
+                assert build_args["add_hosts"] == {"domain": "ip"}
+                assert build_args["builder"] == "builder"
+                assert build_args["cache"] is True
+                assert build_args["cache_from"] == [
+                    {"type": "local", "src": pathlib.Path("~/.holoscan_build_cache")}
+                ]
+                assert build_args["cache_to"] == {
+                    "type": "local",
+                    "dest": pathlib.Path("~/.holoscan_build_cache"),
+                }
+                assert isinstance(build_args["context_path"], str)
+                assert build_args["file"].endswith("/Dockerfile")
+                assert build_args["platforms"] == ["linux/amd64"]
+                assert build_args["progress"] == "auto"
+                assert build_args["pull"] is True
+                assert build_args["tags"] == [
+                    "image-x64-workstation-dgpu-linux-amd64:tag"
+                ]
+                assert build_args["load"] is True
+                assert build_args["build_args"] == {
+                    "UID": os.getuid(),
+                    "GID": os.getgid(),
+                    "UNAME": "holoscan",
+                    "GPU_TYPE": "dgpu",
+                }
+
             monkeypatch.setattr(os.path, "isfile", lambda x: True)
             monkeypatch.setattr(os.path, "isdir", lambda x: False)
             monkeypatch.setattr(os, "access", lambda x, y: True)
+            monkeypatch.setattr(
+                holoscan_cli.packager.container_builder,
+                "build_docker_image",
+                build_docker_image,
+            )
 
             build_parameters = self._get_build_parameters()
             platform_parameters = PlatformParameters(

--- a/tests/unit/packager/test_package_command.py
+++ b/tests/unit/packager/test_package_command.py
@@ -1,0 +1,423 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+from packaging.version import Version
+
+from holoscan_cli.packager.package_command import create_package_parser
+from holoscan_cli.common.constants import SDK
+
+
+class TestPackageCommand:
+    @pytest.fixture
+    def parser(self) -> argparse.ArgumentParser:
+        """
+        Create and return an ArgumentParser instance for testing.
+
+        Returns:
+            argparse.ArgumentParser: The configured argument parser
+        """
+        main_parser = argparse.ArgumentParser(description="Test parser")
+        subparsers = main_parser.add_subparsers(dest="command")
+        return create_package_parser(subparsers, "package", [])
+
+    @pytest.fixture
+    def temp_dir(self, tmp_path: Path) -> Path:
+        """
+        Create a temporary directory for testing file paths.
+
+        Args:
+            tmp_path: Pytest fixture providing a temporary directory path
+
+        Returns:
+            Path: Path to the temporary directory
+        """
+        return tmp_path
+
+    @pytest.fixture
+    def valid_args(self, temp_dir: Path) -> Dict[str, Any]:
+        """
+        Create a dictionary of valid arguments for the package command.
+
+        Args:
+            temp_dir: Temporary directory path
+
+        Returns:
+            Dict[str, Any]: Dictionary of valid arguments
+        """
+        # Create necessary files and directories
+        app_dir = temp_dir / "app"
+        app_dir.mkdir()
+        (app_dir / "__main__.py").touch()
+
+        config_file = temp_dir / "config.yaml"
+        config_file.touch()
+
+        docs_dir = temp_dir / "docs"
+        docs_dir.mkdir()
+        (docs_dir / "README.md").touch()
+
+        models_dir = temp_dir / "models"
+        models_dir.mkdir()
+        (models_dir / "model.onnx").touch()
+
+        additional_lib = temp_dir / "lib"
+        additional_lib.mkdir()
+        (additional_lib / "library.so").touch()
+
+        return {
+            "application": str(app_dir),
+            "config": str(config_file),
+            "docs": str(docs_dir),
+            "models": str(models_dir),
+            "platform": "x86_64",
+            "add": [str(additional_lib)],
+            "timeout": 300,
+            "version": Version("1.0.0"),
+            "add_host": ["example.com:192.168.1.1"],
+            "base_image": "base:latest",
+            "build_image": "build:latest",
+            "includes": ["debug", "holoviz"],
+            "build_cache": str(temp_dir / "cache"),
+            "cmake_args": '"-DCMAKE_BUILD_TYPE=DEBUG"',
+            "no_cache": True,
+            "sdk": "holoscan",
+            "source": "source.json",
+            "sdk_version": Version("0.5.0"),
+            "output": str(temp_dir),
+            "tag": "myapp:1.0",
+            "username": "testuser",
+            "uid": "1001",
+            "gid": "1001",
+        }
+
+    def test_parser_creation(self) -> None:
+        """Test that the parser is created correctly."""
+        main_parser = argparse.ArgumentParser(description="Test parser")
+        subparsers = main_parser.add_subparsers(dest="command")
+        parser = create_package_parser(subparsers, "package", [])
+
+        assert parser is not None
+        assert isinstance(parser, argparse.ArgumentParser)
+
+    def test_required_arguments(
+        self, parser: argparse.ArgumentParser, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Test that required arguments are enforced.
+
+        Args:
+            parser: The argument parser to test
+            monkeypatch: Pytest fixture for patching functions
+        """
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--tag", "myapp:1.0"])
+
+        with pytest.raises(SystemExit):
+            parser.parse_args(["app", "--platform", "x86_64"])
+
+        with pytest.raises(SystemExit):
+            parser.parse_args(["app", "--config", "config.yaml"])
+
+    def test_valid_arguments(
+        self,
+        parser: argparse.ArgumentParser,
+        valid_args: Dict[str, Any],
+        temp_dir: Path,
+    ) -> None:
+        """
+        Test parsing with valid arguments.
+
+        Args:
+            parser: The argument parser to test
+            valid_args: Dictionary of valid arguments
+            temp_dir: Temporary directory path
+        """
+        # Convert the dictionary to command line arguments
+        cmd_args = []
+        for key, value in valid_args.items():
+            if key == "application":
+                cmd_args.insert(0, str(value))  # Positional argument should be first
+                continue
+
+            if isinstance(value, list):
+                for item in value:
+                    if key == "includes":
+                        cmd_args.extend(["--includes", item])
+                    else:
+                        cmd_args.extend([f"--{key.replace('_', '-')}", str(item)])
+            elif value is True:
+                cmd_args.append(f"--{key.replace('_', '-')}")
+            elif value is not False and value is not None:
+                cmd_args.extend([f"--{key.replace('_', '-')}", str(value)])
+
+        args = parser.parse_args(cmd_args)
+
+        # Check that all arguments were parsed correctly
+        for key, expected in valid_args.items():
+            if key == "includes":
+                for item in getattr(args, key):
+                    assert str(item) in expected
+            elif isinstance(expected, list):
+                if key == "add":
+                    for item in getattr(args, "additional_libs"):
+                        assert str(item) in expected
+                elif key == "add_host":
+                    for item in getattr(args, "add_hosts"):
+                        assert str(item) in expected
+                else:
+                    assert getattr(args, key) == expected
+            elif expected is True or expected is False:
+                assert getattr(args, key) == expected
+            elif isinstance(getattr(args, key), list):
+                if isinstance(getattr(args, key)[0], Enum):
+                    for item in getattr(args, key):
+                        assert item.value in expected
+                else:
+                    assert getattr(args, key) == expected
+            elif isinstance(getattr(args, key), Enum):
+                assert getattr(args, key).value == expected
+            elif expected is not None:
+                print("================================================")
+                print(f"key: {key}, expected: {expected}")
+                print(f"type: {type(expected)}")
+                print(f"arg: {getattr(args, key)}")
+                print(f"type: {type(getattr(args, key))}")
+                print("================================================")
+                assert str(getattr(args, key)) == str(expected)
+
+    def test_platform_validation(
+        self,
+        parser: argparse.ArgumentParser,
+        valid_args: Dict[str, Any],
+        temp_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """
+        Test platform validation.
+
+        Args:
+            parser: The argument parser to test
+            valid_args: Dictionary of valid arguments
+            temp_dir: Temporary directory path
+            monkeypatch: Pytest fixture for patching functions
+        """
+        cmd_args = [
+            valid_args["application"],
+            "--config",
+            valid_args["config"],
+            "--platform",
+            "invalid_platform",
+            "--tag",
+            valid_args["tag"],
+        ]
+
+        with pytest.raises(SystemExit):
+            parser.parse_args(cmd_args)
+
+        # Test valid platforms
+        for platform in SDK.PLATFORMS:
+            cmd_args = [
+                valid_args["application"],
+                "--config",
+                valid_args["config"],
+                "--platform",
+                platform,
+                "--tag",
+                valid_args["tag"],
+            ]
+            args = parser.parse_args(cmd_args)
+            assert str(args.platform[0].value) == platform
+
+    def test_sdk_validation(
+        self,
+        parser: argparse.ArgumentParser,
+        valid_args: Dict[str, Any],
+        temp_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """
+        Test SDK validation.
+
+        Args:
+            parser: The argument parser to test
+            valid_args: Dictionary of valid arguments
+            temp_dir: Temporary directory path
+            monkeypatch: Pytest fixture for patching functions
+        """
+        cmd_args = [
+            valid_args["application"],
+            "--config",
+            valid_args["config"],
+            "--platform",
+            valid_args["platform"],
+            "--tag",
+            valid_args["tag"],
+            "--sdk",
+            "invalid_sdk",
+        ]
+
+        with pytest.raises(SystemExit):
+            parser.parse_args(cmd_args)
+
+        # Test valid SDKs
+        for sdk in SDK.SDKS:
+            cmd_args = [
+                valid_args["application"],
+                "--config",
+                valid_args["config"],
+                "--platform",
+                valid_args["platform"],
+                "--tag",
+                valid_args["tag"],
+                "--sdk",
+                sdk,
+            ]
+            args = parser.parse_args(cmd_args)
+            assert str(args.sdk.value) == sdk
+
+    def test_includes_validation(
+        self,
+        parser: argparse.ArgumentParser,
+        valid_args: Dict[str, Any],
+        temp_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """
+        Test includes validation.
+
+        Args:
+            parser: The argument parser to test
+            valid_args: Dictionary of valid arguments
+            temp_dir: Temporary directory path
+            monkeypatch: Pytest fixture for patching functions
+        """
+        cmd_args = [
+            valid_args["application"],
+            "--config",
+            valid_args["config"],
+            "--platform",
+            valid_args["platform"],
+            "--tag",
+            valid_args["tag"],
+            "--includes",
+            "invalid_include",
+        ]
+
+        with pytest.raises(SystemExit):
+            parser.parse_args(cmd_args)
+
+        # Test valid includes
+        valid_includes = ["debug", "holoviz", "torch", "onnx"]
+        for include in valid_includes:
+            cmd_args = [
+                valid_args["application"],
+                "--config",
+                valid_args["config"],
+                "--platform",
+                valid_args["platform"],
+                "--tag",
+                valid_args["tag"],
+                "--includes",
+                include,
+            ]
+            args = parser.parse_args(cmd_args)
+            assert include in args.includes
+
+    def test_version_parsing(
+        self,
+        parser: argparse.ArgumentParser,
+        valid_args: Dict[str, Any],
+        temp_dir: Path,
+    ) -> None:
+        """
+        Test version parsing.
+
+        Args:
+            parser: The argument parser to test
+            valid_args: Dictionary of valid arguments
+            temp_dir: Temporary directory path
+        """
+        cmd_args = [
+            valid_args["application"],
+            "--config",
+            valid_args["config"],
+            "--platform",
+            valid_args["platform"],
+            "--tag",
+            valid_args["tag"],
+            "--version",
+            "1.2.3",
+        ]
+
+        args = parser.parse_args(cmd_args)
+        assert isinstance(args.version, Version)
+        assert str(args.version) == "1.2.3"
+
+        cmd_args = [
+            valid_args["application"],
+            "--config",
+            valid_args["config"],
+            "--platform",
+            valid_args["platform"],
+            "--tag",
+            valid_args["tag"],
+            "--sdk-version",
+            "0.5.1",
+        ]
+
+        args = parser.parse_args(cmd_args)
+        assert isinstance(args.sdk_version, Version)
+        assert str(args.sdk_version) == "0.5.1"
+
+    def test_default_values(
+        self,
+        parser: argparse.ArgumentParser,
+        valid_args: Dict[str, Any],
+        temp_dir: Path,
+    ) -> None:
+        """
+        Test default values.
+
+        Args:
+            parser: The argument parser to test
+            valid_args: Dictionary of valid arguments
+            temp_dir: Temporary directory path
+        """
+        cmd_args = [
+            valid_args["application"],
+            "--config",
+            valid_args["config"],
+            "--platform",
+            valid_args["platform"],
+            "--tag",
+            valid_args["tag"],
+        ]
+
+        args = parser.parse_args(cmd_args)
+
+        # Check default values
+        assert args.username == "holoscan"
+        assert args.uid == 1000
+        assert args.gid == 1000
+        assert args.no_cache is False
+        assert args.includes == []
+        assert str(args.build_cache) == os.path.expanduser("~/.holoscan_build_cache")

--- a/tests/unit/runner/test_run_command.py
+++ b/tests/unit/runner/test_run_command.py
@@ -1,0 +1,303 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from holoscan_cli.runner.run_command import create_run_parser
+
+
+class TestRunCommand:
+    @pytest.fixture
+    def parser(self) -> argparse.ArgumentParser:
+        """
+        Create and return an ArgumentParser instance for testing.
+
+        Returns:
+            argparse.ArgumentParser: The configured argument parser
+        """
+        main_parser = argparse.ArgumentParser(description="Test parser")
+        subparsers = main_parser.add_subparsers(dest="command")
+        return create_run_parser(subparsers, "run", [])
+
+    @pytest.fixture
+    def temp_dir(self, tmp_path: Path) -> Path:
+        """
+        Create a temporary directory for testing file paths.
+
+        Args:
+            tmp_path: Pytest fixture providing a temporary directory path
+
+        Returns:
+            Path: Path to the temporary directory
+        """
+        return tmp_path
+
+    @pytest.fixture
+    def valid_args(self, temp_dir: Path) -> Dict[str, Any]:
+        """
+        Create a dictionary of valid arguments for the run command.
+
+        Args:
+            temp_dir: Temporary directory path
+
+        Returns:
+            Dict[str, Any]: Dictionary of valid arguments
+        """
+        # Create necessary files and directories
+        input_dir = temp_dir / "input"
+        input_dir.mkdir()
+        (input_dir / "data.bin").touch()
+
+        output_dir = temp_dir / "output"
+        output_dir.mkdir()
+
+        config_file = temp_dir / "config.yaml"
+        config_file.touch()
+
+        return {
+            "map": "myapp:1.0",
+            "address": "localhost:8765",
+            "driver": True,
+            "input": str(input_dir),
+            "output": str(output_dir),
+            "fragments": "fragment1,fragment2",
+            "worker": True,
+            "worker_address": "localhost:10000",
+            "rm": True,
+            "config": str(config_file),
+            "name": "test-container",
+            "health_check": True,
+            "network": "custom-network",
+            "nic": "eth0",
+            "use_all_nics": True,
+            "render": True,
+            "quiet": True,
+            "shm_size": "2g",
+            "terminal": True,
+            "device": ["ajantv0", "video1"],
+            "gpus": "all",
+            "uid": "1001",
+            "gid": "1001",
+        }
+
+    def test_parser_creation(self) -> None:
+        """Test that the parser is created correctly."""
+        main_parser = argparse.ArgumentParser(description="Test parser")
+        subparsers = main_parser.add_subparsers(dest="command")
+        parser = create_run_parser(subparsers, "run", [])
+
+        assert parser is not None
+        assert isinstance(parser, argparse.ArgumentParser)
+
+    def test_required_arguments(
+        self, parser: argparse.ArgumentParser, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Test that required arguments are enforced.
+
+        Args:
+            parser: The argument parser to test
+            monkeypatch: Pytest fixture for patching functions
+        """
+        # The only required argument is the map (image name)
+        with pytest.raises(SystemExit):
+            parser.parse_args([])
+
+        # This should work
+        args = parser.parse_args(["myapp:1.0"])
+        assert args.map == "myapp:1.0"
+
+    def test_valid_arguments(
+        self, parser: argparse.ArgumentParser, valid_args: Dict[str, Any]
+    ) -> None:
+        """
+        Test parsing with valid arguments.
+
+        Args:
+            parser: The argument parser to test
+            valid_args: Dictionary of valid arguments
+        """
+        # Convert the dictionary to command line arguments
+        cmd_args = []
+        for key, value in valid_args.items():
+            if key == "map":
+                cmd_args.insert(0, str(value))  # Positional argument should be first
+                continue
+
+            if isinstance(value, list):
+                for item in value:
+                    cmd_args.extend([f"--{key.replace('_', '-')}", str(item)])
+            elif value is True:
+                cmd_args.append(f"--{key.replace('_', '-')}")
+            elif value is not False and value is not None:
+                cmd_args.extend([f"--{key.replace('_', '-')}", str(value)])
+
+        args = parser.parse_args(cmd_args)
+
+        # Check that all arguments were parsed correctly
+        for key, expected in valid_args.items():
+            if isinstance(expected, list):
+                assert getattr(args, key) == expected
+            elif expected is True or expected is False:
+                assert getattr(args, key) == expected
+            elif expected is not None:
+                assert str(getattr(args, key)) == str(expected)
+
+    def test_default_values(self, parser: argparse.ArgumentParser) -> None:
+        """
+        Test default values.
+
+        Args:
+            parser: The argument parser to test
+        """
+        args = parser.parse_args(["myapp:1.0"])
+
+        # Check default values
+        assert args.driver is False
+        assert args.worker is False
+        assert args.rm is False
+        assert args.network == "host"
+        assert args.use_all_nics is False
+        assert args.render is False
+        assert args.quiet is False
+        assert args.terminal is False
+        assert args.health_check == "False"  # Note: This is a string in the code
+        assert args.uid == os.getuid()
+        assert args.gid == os.getgid()
+
+    def test_device_argument(self, parser: argparse.ArgumentParser) -> None:
+        """
+        Test the device argument which can accept multiple values.
+
+        Args:
+            parser: The argument parser to test
+        """
+        # Test with single device
+        args = parser.parse_args(["myapp:1.0", "--device", "ajantv0"])
+        assert args.device == ["ajantv0"]
+
+        # Test with multiple devices
+        args = parser.parse_args(["myapp:1.0", "--device", "ajantv0", "video1"])
+        assert args.device == ["ajantv0", "video1"]
+
+    def test_fragments_parsing(self, parser: argparse.ArgumentParser) -> None:
+        """
+        Test fragments argument parsing.
+
+        Args:
+            parser: The argument parser to test
+        """
+        # Test with comma-separated fragments
+        args = parser.parse_args(
+            ["myapp:1.0", "--fragments", "fragment1,fragment2,fragment3"]
+        )
+        assert args.fragments == "fragment1,fragment2,fragment3"
+
+        # Test with 'all' value
+        args = parser.parse_args(["myapp:1.0", "--fragments", "all"])
+        assert args.fragments == "all"
+
+    def test_path_arguments(
+        self, parser: argparse.ArgumentParser, temp_dir: Path
+    ) -> None:
+        """
+        Test path-related arguments.
+
+        Args:
+            parser: The argument parser to test
+            temp_dir: Temporary directory path
+        """
+        input_dir = temp_dir / "input"
+        input_dir.mkdir()
+
+        output_dir = temp_dir / "output"
+        output_dir.mkdir()
+
+        config_file = temp_dir / "config.yaml"
+        config_file.touch()
+
+        args = parser.parse_args(
+            [
+                "myapp:1.0",
+                "--input",
+                str(input_dir),
+                "--output",
+                str(output_dir),
+                "--config",
+                str(config_file),
+            ]
+        )
+
+        assert str(args.input) == str(input_dir)
+        assert str(args.output) == str(output_dir)
+        assert str(args.config) == str(config_file)
+
+    def test_network_options(self, parser: argparse.ArgumentParser) -> None:
+        """
+        Test network-related options.
+
+        Args:
+            parser: The argument parser to test
+        """
+        args = parser.parse_args(
+            [
+                "myapp:1.0",
+                "--address",
+                "192.168.1.100:8765",
+                "--worker-address",
+                "192.168.1.101:10000",
+                "--network",
+                "custom-network",
+                "--nic",
+                "eth0",
+                "--use-all-nics",
+            ]
+        )
+
+        assert args.address == "192.168.1.100:8765"
+        assert args.worker_address == "192.168.1.101:10000"
+        assert args.network == "custom-network"
+        assert args.nic == "eth0"
+        assert args.use_all_nics is True
+
+    def test_container_options(self, parser: argparse.ArgumentParser) -> None:
+        """
+        Test container-related options.
+
+        Args:
+            parser: The argument parser to test
+        """
+        args = parser.parse_args(
+            [
+                "myapp:1.0",
+                "--name",
+                "test-container",
+                "--rm",
+                "--shm-size",
+                "2g",
+                "--gpus",
+                "all",
+            ]
+        )
+
+        assert args.name == "test-container"
+        assert args.rm is True
+        assert args.shm_size == "2g"
+        assert args.gpus == "all"

--- a/tests/unit/runner/test_runner.py
+++ b/tests/unit/runner/test_runner.py
@@ -109,6 +109,7 @@ class TestRunApp:
             terminal=False,
             device=None,
             shm_size=None,
+            rm=False,
         )
 
         app_info = {"app": "test"}
@@ -157,6 +158,7 @@ class TestRunApp:
             terminal=False,
             device=None,
             shm_size=None,
+            rm=False,
         )
 
         app_info = {"app": "test"}


### PR DESCRIPTION
This PR enables the test-app job in the main workflow, which builds and installs the CLI, then packages and runs the Python test app.

Due to network limitations in the NV GHA runners (unable to resolve some domains with `docker buildx build --builder`), I had to introduce the `--add-host` option to add custom domain name to IP address mapping for all known domain names used when packaging the application. 

- Updated `.github/copy-pr-bot.yaml` to initialize empty lists for additional trustees and vetters.
- Added support for `--add-host` argument in packaging commands and adjusted related classes to handle new parameters.
- Added support for `--rm` to remove the container after "run" exits
- Improved error handling and logging in container operations.
- Updated unit tests to cover new functionality related to host mappings.

A custom Dockerfile has been added and published at https://github.com/nvidia-holoscan/holoscan-cli/pkgs/container/holoscan-cli-build for NV GHA runners. The `test-app` job also utilizes the GitHub Cache to reduce the time to package the application: from [11 minutes](https://github.com/nvidia-holoscan/holoscan-cli/actions/runs/14098947973) to [6.33 minutes](https://github.com/nvidia-holoscan/holoscan-cli/actions/runs/14176902591).