### PR TITLE
CLI patch release 3.4.1 to fix missing package metadata

### DIFF
--- a/releases/3.4.1/artifacts.json
+++ b/releases/3.4.1/artifacts.json
@@ -1,0 +1,89 @@
+{
+  "3.4.1": {
+    "holoscan": {
+      "debian-version": "3.4.0.2-1",
+      "wheel-version": "3.4.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:12.8.1-runtime-ubuntu24.04",
+        "igpu": "nvcr.io/nvidia/tensorrt:25.03-py3-igpu"
+      },
+      "build-images": {
+        "igpu": {
+          "jetson-agx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-igpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-igpu"
+        },
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-dgpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-dgpu",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-dgpu",
+          "clara-agx-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-dgpu"
+        },
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-dgpu"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-arm64"
+    }
+  },
+  "3.4.0": {
+    "holoscan": {
+      "debian-version": "3.4.0.2-1",
+      "wheel-version": "3.4.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:12.8.1-runtime-ubuntu24.04",
+        "igpu": "nvcr.io/nvidia/tensorrt:25.03-py3-igpu"
+      },
+      "build-images": {
+        "igpu": {
+          "jetson-agx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-igpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-igpu"
+        },
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-dgpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-dgpu",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-dgpu",
+          "clara-agx-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-dgpu"
+        },
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-dgpu"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-arm64"
+    }
+  },
+  "3.3.0": {
+    "holoscan": {
+      "debian-version": "3.3.0.1-1",
+      "wheel-version": "3.3.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:12.8.1-runtime-ubuntu24.04",
+        "igpu": "nvcr.io/nvidia/tensorrt:25.03-py3-igpu"
+      },
+      "build-images": {
+        "igpu": {
+          "jetson-agx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.3.0-igpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.3.0-igpu"
+        },
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.3.0-dgpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.3.0-dgpu",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.3.0-dgpu",
+          "clara-agx-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.3.0-dgpu"
+        },
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.3.0-dgpu"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-arm64"
+    }
+  }
+}

--- a/tests/app/expected-output/app/models.txt
+++ b/tests/app/expected-output/app/models.txt
@@ -2,9 +2,9 @@
 
 Listing models in /opt/holoscan/models:
 
-Model 'model-2' found in /opt/holoscan/models/model-2
-
 Model 'model-1' found in /opt/holoscan/models/model-1
+
+Model 'model-2' found in /opt/holoscan/models/model-2
 
 ListModelsOp completed.
 


### PR DESCRIPTION
Re-releasing 3.4.0 as 3.4.1 because of missing PyPI package metadata in the 3.4.0 release.