### PR TITLE
update to release based on v4.1.0

### DIFF
--- a/releases/4.1.0/artifacts-cu12.json
+++ b/releases/4.1.0/artifacts-cu12.json
@@ -9,17 +9,17 @@
       },
       "build-images": {
         "igpu": {
-          "jetson-agx-orin-devkit": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.1-cuda12-igpu",
-          "igx-orin-devkit": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.1-cuda12-igpu"
+          "jetson-agx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.1.0-cuda12-igpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.1.0-cuda12-igpu"
         },
         "dgpu": {
-          "x64-workstation": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.1-cuda12-dgpu",
-          "igx-orin-devkit": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.1-cuda12-dgpu",
-          "sbsa": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.1-cuda12-dgpu",
-          "clara-agx-devkit": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.1-cuda12-dgpu"
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.1.0-cuda12-dgpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.1.0-cuda12-dgpu",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.1.0-cuda12-dgpu",
+          "clara-agx-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.1.0-cuda12-dgpu"
         },
         "cpu": {
-          "x64-workstation": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.1-cuda12-dgpu"
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.1.0-cuda12-dgpu"
         }
       }
     },

--- a/releases/4.1.0/artifacts-cu12.json
+++ b/releases/4.1.0/artifacts-cu12.json
@@ -1,0 +1,350 @@
+{
+  "4.1.0": {
+    "holoscan": {
+      "debian-version": "4.1.0.0-1",
+      "wheel-version": "4.1.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:12.8.1-runtime-ubuntu24.04",
+        "igpu": "nvcr.io/nvidia/l4t-tensorrt:r10.3.0-devel"
+      },
+      "build-images": {
+        "igpu": {
+          "jetson-agx-orin-devkit": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.0-cuda12-igpu",
+          "igx-orin-devkit": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.0-cuda12-igpu"
+        },
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.0-cuda12-dgpu",
+          "igx-orin-devkit": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.0-cuda12-dgpu",
+          "sbsa": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.0-cuda12-dgpu",
+          "clara-agx-devkit": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.0-cuda12-dgpu"
+        },
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.0-cuda12-dgpu"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-arm64"
+    }
+  },
+  "4.0.0": {
+    "holoscan": {
+      "debian-version": "4.0.0.1-1",
+      "wheel-version": "4.0.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:12.8.1-runtime-ubuntu24.04",
+        "igpu": "nvcr.io/nvidia/l4t-tensorrt:r10.3.0-devel"
+      },
+      "build-images": {
+        "igpu": {
+          "jetson-agx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.0.0-cuda12-igpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.0.0-cuda12-igpu"
+        },
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.0.0-cuda12-dgpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.0.0-cuda12-dgpu",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.0.0-cuda12-dgpu",
+          "clara-agx-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.0.0-cuda12-dgpu"
+        },
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.0.0-cuda12-dgpu"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-arm64"
+    }
+  },
+  "3.11.0": {
+    "holoscan": {
+      "debian-version": "3.11.0.2-1",
+      "wheel-version": "3.11.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:12.8.1-runtime-ubuntu24.04",
+        "igpu": "nvcr.io/nvidia/l4t-tensorrt:r10.3.0-devel"
+      },
+      "build-images": {
+        "igpu": {
+          "jetson-agx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.11.0-cuda12-igpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.11.0-cuda12-igpu"
+        },
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.11.0-cuda12-dgpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.11.0-cuda12-dgpu",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.11.0-cuda12-dgpu",
+          "clara-agx-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.11.0-cuda12-dgpu"
+        },
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.11.0-cuda12-dgpu"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-arm64"
+    }
+  },
+  "3.10.0": {
+    "holoscan": {
+      "debian-version": "3.10.0.0-1",
+      "wheel-version": "3.10.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:12.8.1-runtime-ubuntu24.04",
+        "igpu": "nvcr.io/nvidia/l4t-tensorrt:r10.3.0-devel"
+      },
+      "build-images": {
+        "igpu": {
+          "jetson-agx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.10.0-cuda12-igpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.10.0-cuda12-igpu"
+        },
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.10.0-cuda12-dgpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.10.0-cuda12-dgpu",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.10.0-cuda12-dgpu",
+          "clara-agx-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.10.0-cuda12-dgpu"
+        },
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.10.0-cuda12-dgpu"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-arm64"
+    }
+  },
+  "3.9.0": {
+    "holoscan": {
+      "debian-version": "3.9.0.1-1",
+      "wheel-version": "3.9.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:12.8.1-runtime-ubuntu24.04",
+        "igpu": "nvcr.io/nvidia/tensorrt:25.03-py3-igpu"
+      },
+      "build-images": {
+        "igpu": {
+          "jetson-agx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.9.0-cuda12-igpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.9.0-cuda12-igpu"
+        },
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.9.0-cuda12-dgpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.9.0-cuda12-dgpu",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.9.0-cuda12-dgpu",
+          "clara-agx-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.9.0-cuda12-dgpu"
+        },
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.9.0-cuda12-dgpu"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-arm64"
+    }
+  },
+  "3.8.0": {
+    "holoscan": {
+      "debian-version": "3.8.0.1-1",
+      "wheel-version": "3.8.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:12.8.1-runtime-ubuntu24.04",
+        "igpu": "nvcr.io/nvidia/tensorrt:25.03-py3-igpu"
+      },
+      "build-images": {
+        "igpu": {
+          "jetson-agx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.8.0-cuda12-igpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.8.0-cuda12-igpu"
+        },
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.8.0-cuda12-dgpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.8.0-cuda12-dgpu",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.8.0-cuda12-dgpu",
+          "clara-agx-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.8.0-cuda12-dgpu"
+        },
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.8.0-cuda12-dgpu"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-arm64"
+    }
+  },
+  "3.7.0": {
+    "holoscan": {
+      "debian-version": "3.7.0.1-1",
+      "wheel-version": "3.7.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:12.8.1-runtime-ubuntu24.04",
+        "igpu": "nvcr.io/nvidia/tensorrt:25.03-py3-igpu"
+      },
+      "build-images": {
+        "igpu": {
+          "jetson-agx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.7.0-cuda12-igpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.7.0-cuda12-igpu"
+        },
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.7.0-cuda12-dgpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.7.0-cuda12-dgpu",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.7.0-cuda12-dgpu",
+          "clara-agx-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.7.0-cuda12-dgpu"
+        },
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.7.0-cuda12-dgpu"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-arm64"
+    }
+  },
+  "3.6.0": {
+    "holoscan": {
+      "debian-version": "3.6.0.2-1",
+      "wheel-version": "3.6.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:12.8.1-runtime-ubuntu24.04",
+        "igpu": "nvcr.io/nvidia/tensorrt:25.03-py3-igpu"
+      },
+      "build-images": {
+        "igpu": {
+          "jetson-agx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.6.0-igpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.6.0-igpu"
+        },
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.6.0-dgpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.6.0-dgpu",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.6.0-dgpu",
+          "clara-agx-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.6.0-dgpu"
+        },
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.6.0-dgpu"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-arm64"
+    }
+  },
+  "3.5.0": {
+    "holoscan": {
+      "debian-version": "3.5.0.1-1",
+      "wheel-version": "3.5.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:12.8.1-runtime-ubuntu24.04",
+        "igpu": "nvcr.io/nvidia/tensorrt:25.03-py3-igpu"
+      },
+      "build-images": {
+        "igpu": {
+          "jetson-agx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.5.0-igpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.5.0-igpu"
+        },
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.5.0-dgpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.5.0-dgpu",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.5.0-dgpu",
+          "clara-agx-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.5.0-dgpu"
+        },
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.5.0-dgpu"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-arm64"
+    }
+  },
+  "3.4.1": {
+    "holoscan": {
+      "debian-version": "3.4.0.2-1",
+      "wheel-version": "3.4.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:12.8.1-runtime-ubuntu24.04",
+        "igpu": "nvcr.io/nvidia/tensorrt:25.03-py3-igpu"
+      },
+      "build-images": {
+        "igpu": {
+          "jetson-agx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-igpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-igpu"
+        },
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-dgpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-dgpu",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-dgpu",
+          "clara-agx-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-dgpu"
+        },
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-dgpu"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-arm64"
+    }
+  },
+  "3.4.0": {
+    "holoscan": {
+      "debian-version": "3.4.0.2-1",
+      "wheel-version": "3.4.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:12.8.1-runtime-ubuntu24.04",
+        "igpu": "nvcr.io/nvidia/tensorrt:25.03-py3-igpu"
+      },
+      "build-images": {
+        "igpu": {
+          "jetson-agx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-igpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-igpu"
+        },
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-dgpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-dgpu",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-dgpu",
+          "clara-agx-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-dgpu"
+        },
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-dgpu"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-arm64"
+    }
+  },
+  "3.3.0": {
+    "holoscan": {
+      "debian-version": "3.3.0.1-1",
+      "wheel-version": "3.3.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:12.8.1-runtime-ubuntu24.04",
+        "igpu": "nvcr.io/nvidia/tensorrt:25.03-py3-igpu"
+      },
+      "build-images": {
+        "igpu": {
+          "jetson-agx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.3.0-igpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.3.0-igpu"
+        },
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.3.0-dgpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.3.0-dgpu",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.3.0-dgpu",
+          "clara-agx-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.3.0-dgpu"
+        },
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.3.0-dgpu"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-arm64"
+    }
+  }
+}

--- a/releases/4.1.0/artifacts-cu12.json
+++ b/releases/4.1.0/artifacts-cu12.json
@@ -1,7 +1,7 @@
 {
   "4.1.0": {
     "holoscan": {
-      "debian-version": "4.1.0.0-1",
+      "debian-version": "4.1.0.1-1",
       "wheel-version": "4.1.0",
       "base-images": {
         "dgpu": "nvcr.io/nvidia/cuda:12.8.1-runtime-ubuntu24.04",
@@ -9,17 +9,17 @@
       },
       "build-images": {
         "igpu": {
-          "jetson-agx-orin-devkit": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.0-cuda12-igpu",
-          "igx-orin-devkit": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.0-cuda12-igpu"
+          "jetson-agx-orin-devkit": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.1-cuda12-igpu",
+          "igx-orin-devkit": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.1-cuda12-igpu"
         },
         "dgpu": {
-          "x64-workstation": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.0-cuda12-dgpu",
-          "igx-orin-devkit": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.0-cuda12-dgpu",
-          "sbsa": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.0-cuda12-dgpu",
-          "clara-agx-devkit": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.0-cuda12-dgpu"
+          "x64-workstation": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.1-cuda12-dgpu",
+          "igx-orin-devkit": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.1-cuda12-dgpu",
+          "sbsa": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.1-cuda12-dgpu",
+          "clara-agx-devkit": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.1-cuda12-dgpu"
         },
         "cpu": {
-          "x64-workstation": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.0-cuda12-dgpu"
+          "x64-workstation": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.1-cuda12-dgpu"
         }
       }
     },

--- a/releases/4.1.0/artifacts.json
+++ b/releases/4.1.0/artifacts.json
@@ -1,19 +1,19 @@
 {
   "4.1.0": {
     "holoscan": {
-      "debian-version": "4.1.0.0-1",
+      "debian-version": "4.1.0.1-1",
       "wheel-version": "4.1.0",
       "base-images": {
         "dgpu": "nvcr.io/nvidia/cuda:13.0.0-runtime-ubuntu24.04"
       },
       "build-images": {
         "dgpu": {
-          "x64-workstation": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.0-cuda13",
-          "sbsa": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.0-cuda13"
+          "x64-workstation": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.1-cuda13",
+          "sbsa": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.1-cuda13"
         },
         "igpu": {},
         "cpu": {
-          "x64-workstation": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.0-cuda13"
+          "x64-workstation": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.1-cuda13"
         }
       }
     },

--- a/releases/4.1.0/artifacts.json
+++ b/releases/4.1.0/artifacts.json
@@ -1,0 +1,163 @@
+{
+  "4.1.0": {
+    "holoscan": {
+      "debian-version": "4.1.0.0-1",
+      "wheel-version": "4.1.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:13.0.0-runtime-ubuntu24.04"
+      },
+      "build-images": {
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.0-cuda13",
+          "sbsa": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.0-cuda13"
+        },
+        "igpu": {},
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.0-cuda13"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-arm64"
+    }
+  },
+  "4.0.0": {
+    "holoscan": {
+      "debian-version": "4.0.0.1-1",
+      "wheel-version": "4.0.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:13.0.0-runtime-ubuntu24.04"
+      },
+      "build-images": {
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.0.0-cuda13",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.0.0-cuda13"
+        },
+        "igpu": {},
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.0.0-cuda13"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-arm64"
+    }
+  },
+  "3.11.0": {
+    "holoscan": {
+      "debian-version": "3.11.0.2-1",
+      "wheel-version": "3.11.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:13.0.0-runtime-ubuntu24.04"
+      },
+      "build-images": {
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.11.0-cuda13",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.11.0-cuda13"
+        },
+        "igpu": {},
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.11.0-cuda13"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-arm64"
+    }
+  },
+  "3.10.0": {
+    "holoscan": {
+      "debian-version": "3.10.0.0-1",
+      "wheel-version": "3.10.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:13.0.0-runtime-ubuntu24.04"
+      },
+      "build-images": {
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.10.0-cuda13",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.10.0-cuda13"
+        },
+        "igpu": {},
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.10.0-cuda13"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-arm64"
+    }
+  },
+  "3.9.0": {
+    "holoscan": {
+      "debian-version": "3.9.0.1-1",
+      "wheel-version": "3.9.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:13.0.0-runtime-ubuntu24.04"
+      },
+      "build-images": {
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.9.0-cuda13",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.9.0-cuda13"
+        },
+        "igpu": {},
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.9.0-cuda13"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-arm64"
+    }
+  },
+  "3.8.0": {
+    "holoscan": {
+      "debian-version": "3.8.0.1-1",
+      "wheel-version": "3.8.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:13.0.0-runtime-ubuntu24.04"
+      },
+      "build-images": {
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.8.0-cuda13",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.8.0-cuda13"
+        },
+        "igpu": {},
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.8.0-cuda13"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-arm64"
+    }
+  },
+  "3.7.0": {
+    "holoscan": {
+      "debian-version": "3.7.0.1-1",
+      "wheel-version": "3.7.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:13.0.0-runtime-ubuntu24.04"
+      },
+      "build-images": {
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.7.0-cuda13",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.7.0-cuda13"
+        },
+        "igpu": {},
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v3.7.0-cuda13"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-arm64"
+    }
+  }
+}

--- a/releases/4.1.0/artifacts.json
+++ b/releases/4.1.0/artifacts.json
@@ -8,12 +8,12 @@
       },
       "build-images": {
         "dgpu": {
-          "x64-workstation": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.1-cuda13",
-          "sbsa": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.1-cuda13"
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.1.0-cuda13",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.1.0-cuda13"
         },
         "igpu": {},
         "cpu": {
-          "x64-workstation": "nvcr.io/nvstaging/holoscan/holoscan:v4.1.0.1-cuda13"
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.1.0-cuda13"
         }
       }
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added release artifact metadata for Holoscan 4.1.0 (and prior 3.x/4.0 entries), including CUDA 12.8.1 and CUDA 13 runtime container mappings, platform-specific build images for dGPU, iGPU and CPU targets (Jetson AGX Orin, IGX Orin, x64 workstations, SBSA, Clara), and standardized health-probe download entries for linux/amd64 and linux/arm64.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->