### PR TITLE
setup: include build-essential in default packages

### DIFF
--- a/src/holoscan_cli/commands/setup_cmd.py
+++ b/src/holoscan_cli/commands/setup_cmd.py
@@ -83,8 +83,21 @@ def handle_setup(cli, args: argparse.Namespace) -> None:
         sys.exit(0)
 
     if not args.scripts:
+        # `build-essential` pulls in gcc/g++/make — without it, CUDA base
+        # images (e.g. `nvcr.io/nvidia/cuda:*-base-*`) ship with `ninja-build`
+        # but no compiler, so cmake fails with `No CMAKE_C_COMPILER could
+        # be found` the moment a downstream project tries to configure.
         install_packages_if_missing(
-            ["wget", "xvfb", "git", "unzip", "ffmpeg", "ninja-build", "libv4l-dev"],
+            [
+                "build-essential",
+                "wget",
+                "xvfb",
+                "git",
+                "unzip",
+                "ffmpeg",
+                "ninja-build",
+                "libv4l-dev",
+            ],
             dry_run=args.dryrun,
         )
 


### PR DESCRIPTION
## Summary

- Add `build-essential` to the default `holoscan setup` package list so CUDA-base images (which ship `ninja-build` but no compiler) leave behind a working gcc/g++/make.
- No-op on bases that already ship gcc (SDK images, Ubuntu desktop), since `install_packages_if_missing` skips already-present packages.

## Why

Holohub Jenkins build #484 (`cuda12base-2404` stage, base = `nvcr.io/nvidia/cuda:12.9.1-base-ubuntu24.04`) failed in the post-setup cmake configure step:

\`\`\`
CMake Error at applications/myproj/CMakeLists.txt:18 (project):
  No CMAKE_C_COMPILER could be found.
  No CMAKE_CXX_COMPILER could be found.
\`\`\`

The default \`holoscan setup\` already provisions \`cmake\`, \`ninja-build\`, \`python3-dev\`, cuDNN, TensorRT, etc. — adding a compiler is the missing piece for the contract "after \`holoscan setup\`, a downstream Holoscan project can be configured and built." This change makes that contract hold on bare CUDA bases.

## Test plan

- [x] Pre-commit (ruff, isort, black, codespell) passes on the diff
- [ ] Manually: run \`holoscan setup\` on a fresh \`nvcr.io/nvidia/cuda:12.9.1-base-ubuntu24.04\` container and confirm \`gcc --version\` works
- [ ] Holohub Jenkins \`cuda12base-2404\` stage goes green once this lands on \`main\` (the holohub Dockerfile installs holoscan-cli from \`git+https://github.com/nvidia-holoscan/holoscan-cli.git@main\` for that stage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved code clarity in the setup process with enhanced comments and reformatted configuration lists.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nvidia-holoscan/holoscan-cli/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->