### PR TITLE
test(cli): pin top-level --help surface as the consolidated-CLI probe contract

### DIFF
--- a/tests/unit/test_cli_parser.py
+++ b/tests/unit/test_cli_parser.py
@@ -22,12 +22,17 @@ internal refactors cannot accidentally change the public CLI contract.
 
 from __future__ import annotations
 
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from holoscan_cli import cli as project_cli
-from holoscan_cli.__main__ import PROJECT_COMMANDS
+from holoscan_cli.__main__ import PROJECT_COMMANDS, parse_args
 from holoscan_cli.commands import registry
 
 # ---- registry / dispatch consistency ----------------------------------------
@@ -150,3 +155,66 @@ def test_holohub_container_alias_was_removed():
     from holoscan_cli import container
 
     assert not hasattr(container, "HoloHubContainer")
+
+
+# ---- top-level ``--help`` surface (shell-probe contract) --------------------
+#
+# Downstream Dockerfiles and wrappers detect the *consolidated* CLI with a
+# shell probe -- ``holoscan --help | grep -qw build``. It is reliable because
+# the legacy packaging-only holoscan-cli (<= 4.2.0) exposes only
+# ``package/run/version/nics``, while the consolidated CLI's top-level help
+# enumerates every source-project command. These tests pin that contract so an
+# internal refactor cannot silently break those probes.
+
+
+def test_top_level_help_lists_every_source_project_command(capsys):
+    """``holoscan --help`` enumerates every registered source-project command."""
+    with pytest.raises(SystemExit) as exc_info:
+        parse_args(["holoscan", "--help"])
+    assert exc_info.value.code == 0
+    help_text = capsys.readouterr().out
+
+    # Mirror ``grep -w <name>``: word-boundary match against the rendered help.
+    missing = [
+        spec.name
+        for spec in registry.PROJECT_COMMANDS
+        if not re.search(rf"\b{re.escape(spec.name)}\b", help_text)
+    ]
+    assert not missing, f"`holoscan --help` omits source-project commands: {missing}"
+
+
+def test_build_token_discriminates_consolidated_from_legacy_cli(capsys):
+    """``grep -qw build`` is a valid version check; ``grep -qw version`` is not.
+
+    ``build`` is a source-project command unique to the consolidated CLI,
+    whereas ``version`` is a native command the legacy holoscan-cli (<= 4.2.0)
+    also ships -- so only a source-project command distinguishes the two.
+    """
+    assert "build" in PROJECT_COMMANDS
+    assert "version" not in PROJECT_COMMANDS
+
+    with pytest.raises(SystemExit):
+        parse_args(["holoscan", "--help"])
+    assert re.search(r"\bbuild\b", capsys.readouterr().out)
+
+
+def test_help_grep_probe_succeeds_from_any_directory(tmp_path):
+    """End-to-end check of the literal ``holoscan --help | grep -qw build`` probe.
+
+    Invoked via ``python -m holoscan_cli`` (no console script required) from an
+    unrelated working directory, proving the help surface is not project-context
+    dependent -- exactly the conditions under which downstream wrappers run it.
+    """
+    import holoscan_cli
+
+    src_dir = Path(holoscan_cli.__file__).resolve().parents[1]
+    env = {**os.environ, "PYTHONPATH": str(src_dir)}
+    proc = subprocess.run(
+        [sys.executable, "-m", "holoscan_cli", "--help"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=tmp_path,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert re.search(r"\bbuild\b", proc.stdout), proc.stdout  # `grep -qw build`


### PR DESCRIPTION
## Context

HoloHub's Dockerfiles and wrappers detect whether the **consolidated**
`holoscan-cli` is installed (vs. the legacy packaging-only CLI,
`holoscan-cli <= 4.2.0`) with a small shell probe:

```sh
holoscan --help | grep -qw build
```

This works because the legacy CLI exposes only `package/run/version/nics`,
while the consolidated CLI's **top-level** `--help` enumerates every
source-project command (`build`, `list`, `create`, ...). `holoscan version`
exists in *both* CLIs, so only a source-project command can discriminate.

There was previously no test pinning that top-level surface, so an internal
refactor could silently break those downstream probes.

## Change

Adds three contract tests to `tests/unit/test_cli_parser.py` (whose stated
purpose is pinning *"behaviors that downstream wrappers and shell scripts rely
on"*):

1. **`test_top_level_help_lists_every_source_project_command`** — `holoscan
   --help` lists every registered source-project command (word-boundary match,
   mirroring `grep -w`).
2. **`test_build_token_discriminates_consolidated_from_legacy_cli`** — `build`
   is a source-project command (a valid probe token); `version` is not.
3. **`test_help_grep_probe_succeeds_from_any_directory`** — end-to-end: runs
   `python -m holoscan_cli --help` from an unrelated working directory and
   asserts the `grep -qw build` match, proving the surface is
   context-independent.

Tests only — no production code changes.

## Test

```
$ pytest tests/unit/test_cli_parser.py -k "top_level_help or build_token or grep_probe" -v
test_top_level_help_lists_every_source_project_command PASSED
test_build_token_discriminates_consolidated_from_legacy_cli PASSED
test_help_grep_probe_succeeds_from_any_directory PASSED
3 passed
```
Full file: 48 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for CLI help functionality and cross-environment validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nvidia-holoscan/holoscan-cli/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->