### PR TITLE
Decouple base image defaults from CLI version

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,32 @@ pip install holoscan-cli
 holoscan --help
 ```
 
+## Versioning
+
+`holoscan-cli` release versions are aligned with Holoscan SDK GA release
+versions. For example, the CLI released with Holoscan SDK 4.4.0 is published as
+`holoscan-cli==4.4.0`; the CLI released with Holoscan SDK 4.5.0 is published as
+`holoscan-cli==4.5.0`.
+
+CLI-only fixes between SDK releases use the patch component for the current SDK
+release line, for example `holoscan-cli==4.4.1` before the next SDK-aligned
+`4.5.0` release.
+
+Version alignment does not imply that the CLI selects, installs, or requires a
+matching Holoscan SDK runtime or container base image. For container builds,
+choose the base image explicitly with `--base-img` or configure one in the
+environment:
+
+```bash
+export HOLOSCAN_CLI_BASE_IMAGE=nvcr.io/nvidia/clara-holoscan/holoscan:v4.4.0-cuda13
+holoscan build-container my_app
+```
+
+If you prefer to keep the base repository and SDK version separate, set
+`HOLOSCAN_CLI_BASE_SDK_VERSION` to derive the default Holoscan SDK base image
+tag. If neither an explicit base image nor a base SDK version is configured, the
+CLI asks for a base image instead of inferring one from its own package version.
+
 ## Build from source
 
 Python 3.10+ and [Poetry 2.0+](https://python-poetry.org/docs/#installation) required.

--- a/README.md
+++ b/README.md
@@ -72,10 +72,19 @@ export HOLOSCAN_CLI_BASE_IMAGE=nvcr.io/nvidia/clara-holoscan/holoscan:v4.4.0-cud
 holoscan build-container my_app
 ```
 
-If you prefer to keep the base repository and SDK version separate, set
-`HOLOSCAN_CLI_BASE_SDK_VERSION` to derive the default Holoscan SDK base image
-tag. If neither an explicit base image nor a base SDK version is configured, the
-CLI asks for a base image instead of inferring one from its own package version.
+Wrapper repos can also configure the Holoscan SDK container repository and SDK
+version separately:
+
+```bash
+export HOLOSCAN_CLI_BASE_IMAGE=nvcr.io/nvidia/clara-holoscan/holoscan
+export HOLOSCAN_CLI_BASE_SDK_VERSION=4.4.0
+holoscan build-container my_app
+```
+
+With the default CUDA selection, that derives the full base image string
+`nvcr.io/nvidia/clara-holoscan/holoscan:v4.4.0-cuda13`. If neither an explicit
+base image tag nor a base SDK version is configured, the CLI asks for a base
+image instead of inferring one from its own package version.
 
 ## Build from source
 

--- a/src/holoscan_cli/commands/create.py
+++ b/src/holoscan_cli/commands/create.py
@@ -171,9 +171,10 @@ def handle_create(cli, args: argparse.Namespace) -> None:
         "project_name": args.project,
         "project_slug": project_slug,
         "language": args.language.lower() if args.language else None,  # Only set if provided
-        "holoscan_version": HoloscanContainer.BASE_SDK_VERSION,
         "year": datetime.datetime.now().year,
     }
+    if HoloscanContainer.BASE_SDK_VERSION:
+        context["holoscan_version"] = HoloscanContainer.BASE_SDK_VERSION
 
     # For module templates the generated folder is the kebab module_repo_name
     # (holoscan-<slug>) rather than the snake_case slug.

--- a/src/holoscan_cli/container/core.py
+++ b/src/holoscan_cli/container/core.py
@@ -93,9 +93,7 @@ class HoloscanContainer:
 
     # Image naming format templates
     DEFAULT_BASE_IMAGE_NAME = "nvcr.io/nvidia/clara-holoscan/holoscan"
-    BASE_IMAGE_NAME = os.environ.get(
-        "HOLOSCAN_CLI_BASE_IMAGE", DEFAULT_BASE_IMAGE_NAME
-    )
+    BASE_IMAGE_NAME = os.environ.get("HOLOSCAN_CLI_BASE_IMAGE", DEFAULT_BASE_IMAGE_NAME)
     BASE_IMAGE_FORMAT = os.environ.get("HOLOSCAN_CLI_BASE_IMAGE_FORMAT") or None
     DEFAULT_IMAGE_FORMAT = os.environ.get("HOLOSCAN_CLI_DEFAULT_IMAGE_FORMAT") or None
     # Additional Default build arguments for docker build command (e.g., --build-context flags)

--- a/src/holoscan_cli/container/core.py
+++ b/src/holoscan_cli/container/core.py
@@ -42,7 +42,6 @@ from ..utils.holohub import (
 )
 from ..utils.io import fatal, info, run_command, warn
 from ..utils.sdk import (
-    DEFAULT_BASE_SDK_VERSION,
     check_nvidia_ctk,
     find_hsdk_build_rel_dir,
     get_arch_gpu_str,
@@ -84,7 +83,7 @@ class HoloscanContainer:
 
     # SDK and path configuration
     SDK_PATH = os.environ.get("HOLOSCAN_CLI_DEFAULT_HSDK_DIR", "/opt/nvidia/holoscan")
-    BASE_SDK_VERSION = os.environ.get("HOLOSCAN_CLI_BASE_SDK_VERSION", DEFAULT_BASE_SDK_VERSION)
+    BASE_SDK_VERSION = os.environ.get("HOLOSCAN_CLI_BASE_SDK_VERSION") or None
     BENCHMARKING_SUBDIR = os.environ.get(
         "HOLOSCAN_CLI_BENCHMARKING_SUBDIR", "benchmarks/holoscan_flow_benchmarking"
     )
@@ -93,15 +92,12 @@ class HoloscanContainer:
     )
 
     # Image naming format templates
+    DEFAULT_BASE_IMAGE_NAME = "nvcr.io/nvidia/clara-holoscan/holoscan"
     BASE_IMAGE_NAME = os.environ.get(
-        "HOLOSCAN_CLI_BASE_IMAGE", "nvcr.io/nvidia/clara-holoscan/holoscan"
+        "HOLOSCAN_CLI_BASE_IMAGE", DEFAULT_BASE_IMAGE_NAME
     )
-    BASE_IMAGE_FORMAT = os.environ.get(
-        "HOLOSCAN_CLI_BASE_IMAGE_FORMAT", "{base_image}:v{sdk_version}-{cuda_tag}"
-    )
-    DEFAULT_IMAGE_FORMAT = os.environ.get(
-        "HOLOSCAN_CLI_DEFAULT_IMAGE_FORMAT", "{container_prefix}:ngc-v{sdk_version}-{cuda_tag}"
-    )
+    BASE_IMAGE_FORMAT = os.environ.get("HOLOSCAN_CLI_BASE_IMAGE_FORMAT") or None
+    DEFAULT_IMAGE_FORMAT = os.environ.get("HOLOSCAN_CLI_DEFAULT_IMAGE_FORMAT") or None
     # Additional Default build arguments for docker build command (e.g., --build-context flags)
     DEFAULT_DOCKER_BUILD_ARGS = os.environ.get("HOLOSCAN_CLI_DEFAULT_DOCKER_BUILD_ARGS", "")
     # Additional Default run arguments for docker run command
@@ -127,20 +123,47 @@ class HoloscanContainer:
         return ["--build-context", f"holoscan-cli-src={source}"]
 
     @classmethod
+    def _format_image_template(cls, template: str, **values: Optional[str]) -> str:
+        if "{sdk_version" in template and not values.get("sdk_version"):
+            fatal(
+                "Image format references sdk_version, but HOLOSCAN_CLI_BASE_SDK_VERSION "
+                "is not set."
+            )
+        return template.format(**values)
+
+    @classmethod
     def default_base_image(cls, cuda_version: Optional[Union[str, int]] = None) -> str:
-        return cls.BASE_IMAGE_FORMAT.format(
-            base_image=cls.BASE_IMAGE_NAME,
-            sdk_version=cls.BASE_SDK_VERSION,
-            cuda_tag=get_cuda_tag(cuda_version, cls.BASE_SDK_VERSION),
+        cuda_tag = get_cuda_tag(cuda_version, cls.BASE_SDK_VERSION)
+        if cls.BASE_IMAGE_FORMAT:
+            return cls._format_image_template(
+                cls.BASE_IMAGE_FORMAT,
+                base_image=cls.BASE_IMAGE_NAME,
+                sdk_version=cls.BASE_SDK_VERSION,
+                cuda_tag=cuda_tag,
+            )
+        if cls.BASE_SDK_VERSION:
+            return f"{cls.BASE_IMAGE_NAME}:v{cls.BASE_SDK_VERSION}-{cuda_tag}"
+        if cls.BASE_IMAGE_NAME != cls.DEFAULT_BASE_IMAGE_NAME:
+            return cls.BASE_IMAGE_NAME
+        fatal(
+            "No default Holoscan SDK base image is configured. Pass --base-img, "
+            "set HOLOSCAN_CLI_BASE_IMAGE to a fully qualified image tag, or set "
+            "HOLOSCAN_CLI_BASE_SDK_VERSION."
         )
 
     @classmethod
     def default_image(cls, cuda_version: Optional[Union[str, int]] = None) -> str:
-        return cls.DEFAULT_IMAGE_FORMAT.format(
-            container_prefix=cls.CONTAINER_PREFIX,
-            sdk_version=cls.BASE_SDK_VERSION,
-            cuda_tag=get_cuda_tag(cuda_version, cls.BASE_SDK_VERSION),
-        )
+        cuda_tag = get_cuda_tag(cuda_version, cls.BASE_SDK_VERSION)
+        if cls.DEFAULT_IMAGE_FORMAT:
+            return cls._format_image_template(
+                cls.DEFAULT_IMAGE_FORMAT,
+                container_prefix=cls.CONTAINER_PREFIX,
+                sdk_version=cls.BASE_SDK_VERSION,
+                cuda_tag=cuda_tag,
+            )
+        if cls.BASE_SDK_VERSION:
+            return f"{cls.CONTAINER_PREFIX}:ngc-v{cls.BASE_SDK_VERSION}-{cuda_tag}"
+        return f"{cls.CONTAINER_PREFIX}:ngc-{cuda_tag}"
 
     @classmethod
     def default_dockerfile(cls) -> Path:
@@ -449,13 +472,13 @@ class HoloscanContainer:
             "--build-arg",
             f"GPU_TYPE={gpu_type}",
             "--build-arg",
-            f"BASE_SDK_VERSION={self.BASE_SDK_VERSION}",
-            "--build-arg",
             f"COMPUTE_CAPACITY={compute_capacity}",
             "--build-arg",
             f"CUDA_MAJOR={cuda_major}",
             "--network=host",
         ]
+        if self.BASE_SDK_VERSION:
+            cmd.extend(["--build-arg", f"BASE_SDK_VERSION={self.BASE_SDK_VERSION}"])
 
         if no_cache:
             cmd.append("--no-cache")

--- a/src/holoscan_cli/utils/sdk.py
+++ b/src/holoscan_cli/utils/sdk.py
@@ -34,8 +34,6 @@ from typing import Optional, Union
 from holoscan_cli.utils.io import fatal, run_info_command, warn
 from holoscan_cli.utils.text import parse_semantic_version
 
-DEFAULT_BASE_SDK_VERSION = "4.2.0"
-
 
 def check_nvidia_ctk(min_version: str = "1.12.0", recommended_version: str = "1.14.1") -> None:
     """Check NVIDIA Container Toolkit version"""
@@ -140,7 +138,9 @@ def get_default_cuda_version() -> str:
     return result
 
 
-def get_cuda_tag(cuda_version: Optional[Union[str, int]] = None, sdk_version: str = "3.6.1") -> str:
+def get_cuda_tag(
+    cuda_version: Optional[Union[str, int]] = None, sdk_version: Optional[str] = None
+) -> str:
     """
     Determine the CUDA container tag based on CUDA version and GPU type.
 
@@ -154,16 +154,19 @@ def get_cuda_tag(cuda_version: Optional[Union[str, int]] = None, sdk_version: st
 
     Args:
         cuda_version: CUDA major version (e.g., 12, 13). If None, uses platform default.
-        sdk_version: SDK version string (e.g., "3.6.0", "3.6.1", "3.7.0").
+        sdk_version: Optional SDK version string (e.g., "3.6.0", "3.6.1", "3.7.0").
+            When omitted or unparsable, the current CUDA tag scheme is used.
 
     Returns:
         The appropriate container tag string
     """
-    try:
-        sdk_ver = parse_semantic_version(sdk_version)
-    except (ValueError, IndexError):
-        sdk_ver = parse_semantic_version(DEFAULT_BASE_SDK_VERSION)
-    if sdk_ver < (3, 6, 1):
+    sdk_ver = None
+    if sdk_version:
+        try:
+            sdk_ver = parse_semantic_version(sdk_version)
+        except (ValueError, IndexError):
+            sdk_ver = None
+    if sdk_ver is not None and sdk_ver < (3, 6, 1):
         return get_host_gpu()
     if sdk_ver == (3, 6, 1):
         return "cuda13-dgpu"

--- a/tests/unit/test_container_core.py
+++ b/tests/unit/test_container_core.py
@@ -124,9 +124,7 @@ def test_default_image_does_not_include_sdk_version_unless_configured(tmp_path, 
     assert c.image_name == "holohub:ngc-cuda13"
 
 
-def test_default_base_image_requires_explicit_base_when_sdk_version_unset(
-    tmp_path, monkeypatch
-):
+def test_default_base_image_requires_explicit_base_when_sdk_version_unset(tmp_path, monkeypatch):
     monkeypatch.setattr(HoloscanContainer, "BASE_SDK_VERSION", None, raising=False)
     monkeypatch.setattr(HoloscanContainer, "BASE_IMAGE_FORMAT", None, raising=False)
     c = _stub_container(tmp_path, project_metadata=None)
@@ -135,9 +133,7 @@ def test_default_base_image_requires_explicit_base_when_sdk_version_unset(
         c.default_base_image()
 
 
-def test_default_base_image_uses_explicit_base_image_without_sdk_version(
-    tmp_path, monkeypatch
-):
+def test_default_base_image_uses_explicit_base_image_without_sdk_version(tmp_path, monkeypatch):
     monkeypatch.setattr(HoloscanContainer, "BASE_SDK_VERSION", None, raising=False)
     monkeypatch.setattr(HoloscanContainer, "BASE_IMAGE_FORMAT", None, raising=False)
     monkeypatch.setattr(HoloscanContainer, "BASE_IMAGE_NAME", "example.com/base:tag", raising=False)

--- a/tests/unit/test_container_core.py
+++ b/tests/unit/test_container_core.py
@@ -40,12 +40,14 @@ from holoscan_cli.container.core import HoloscanContainer
 @pytest.fixture(autouse=True)
 def _isolate_container_class_attrs(monkeypatch):
     """Pin HoloscanContainer class attrs so individual tests can assert against
-    a known REPO_PREFIX/CONTAINER_PREFIX/BASE_SDK_VERSION irrespective of the
-    user's env.
+    known container/image defaults irrespective of the user's env.
     """
     monkeypatch.setattr(HoloscanContainer, "REPO_PREFIX", "holohub", raising=False)
     monkeypatch.setattr(HoloscanContainer, "CONTAINER_PREFIX", "holohub", raising=False)
     monkeypatch.setattr(HoloscanContainer, "BASE_SDK_VERSION", "4.2.0", raising=False)
+    monkeypatch.setattr(
+        HoloscanContainer, "DEFAULT_BASE_IMAGE_NAME", "nvcr.io/x/holoscan", raising=False
+    )
     monkeypatch.setattr(HoloscanContainer, "BASE_IMAGE_NAME", "nvcr.io/x/holoscan", raising=False)
     monkeypatch.setattr(
         HoloscanContainer,
@@ -110,6 +112,38 @@ def test_image_name_falls_back_to_default_image_when_dockerfile_is_default(tmp_p
     name = c.image_name
     # Default image format: "{container_prefix}:ngc-v{sdk_version}-{cuda_tag}"
     assert name.startswith("holohub:ngc-v4.2.0-cuda13")
+
+
+def test_default_image_does_not_include_sdk_version_unless_configured(tmp_path, monkeypatch):
+    monkeypatch.setattr(HoloscanContainer, "BASE_SDK_VERSION", None, raising=False)
+    monkeypatch.setattr(HoloscanContainer, "BASE_IMAGE_FORMAT", None, raising=False)
+    monkeypatch.setattr(HoloscanContainer, "DEFAULT_IMAGE_FORMAT", None, raising=False)
+    monkeypatch.setattr(container_core, "get_default_cuda_version", lambda: "13")
+    c = _stub_container(tmp_path, project_metadata=None)
+
+    assert c.image_name == "holohub:ngc-cuda13"
+
+
+def test_default_base_image_requires_explicit_base_when_sdk_version_unset(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(HoloscanContainer, "BASE_SDK_VERSION", None, raising=False)
+    monkeypatch.setattr(HoloscanContainer, "BASE_IMAGE_FORMAT", None, raising=False)
+    c = _stub_container(tmp_path, project_metadata=None)
+
+    with pytest.raises(SystemExit):
+        c.default_base_image()
+
+
+def test_default_base_image_uses_explicit_base_image_without_sdk_version(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(HoloscanContainer, "BASE_SDK_VERSION", None, raising=False)
+    monkeypatch.setattr(HoloscanContainer, "BASE_IMAGE_FORMAT", None, raising=False)
+    monkeypatch.setattr(HoloscanContainer, "BASE_IMAGE_NAME", "example.com/base:tag", raising=False)
+    c = _stub_container(tmp_path, project_metadata=None)
+
+    assert c.default_base_image() == "example.com/base:tag"
 
 
 def test_image_name_uses_project_tag_when_dockerfile_is_overridden(tmp_path, monkeypatch):
@@ -390,6 +424,37 @@ def test_build_dryrun_emits_base_and_extra_script_layers(tmp_path, monkeypatch):
     assert "SCRIPT=utilities/setup/coverage.sh" in layer
     assert str(setup_dir / "Dockerfile.util") in layer
     assert "holohub-my_app:feature-x-coverage" in layer
+
+
+def test_build_dryrun_omits_base_sdk_version_when_not_configured(tmp_path, monkeypatch):
+    project_dir = tmp_path / "applications" / "my_app"
+    project_dir.mkdir(parents=True)
+    dockerfile = project_dir / "Dockerfile"
+    dockerfile.write_text("FROM scratch\n", encoding="utf-8")
+
+    calls = []
+    monkeypatch.setattr(HoloscanContainer, "BASE_SDK_VERSION", None, raising=False)
+    monkeypatch.setattr(HoloscanContainer, "BASE_IMAGE_FORMAT", None, raising=False)
+    monkeypatch.setattr(container_core, "get_default_cuda_version", lambda: "13")
+    monkeypatch.setattr(container_core, "get_host_gpu", lambda: "dgpu")
+    monkeypatch.setattr(container_core, "get_compute_capacity", lambda: "90")
+    monkeypatch.setattr(container_core, "run_command", lambda cmd, **kwargs: calls.append(cmd))
+
+    c = _stub_container(
+        tmp_path,
+        project_metadata={
+            "project_name": "my_app",
+            "source_folder": str(project_dir),
+            "metadata": {"language": "python"},
+        },
+    )
+    c.dryrun = True
+
+    c.build(base_img="example.com/base:tag")
+
+    first = calls[0]
+    assert "BASE_IMAGE=example.com/base:tag" in first
+    assert not any(arg.startswith("BASE_SDK_VERSION=") for arg in first)
 
 
 def test_run_dryrun_assembles_docker_command_without_runtime_checks(tmp_path, monkeypatch):

--- a/tests/unit/test_create_module.py
+++ b/tests/unit/test_create_module.py
@@ -90,6 +90,18 @@ def test_dryrun_application_template_uses_slug_output_folder(fake_cli, tmp_path,
     assert "applications/CMakeLists.txt" in captured
 
 
+def test_dryrun_omits_holoscan_version_when_not_configured(
+    fake_cli, tmp_path, capsys, monkeypatch
+):
+    monkeypatch.setattr(create.HoloscanContainer, "BASE_SDK_VERSION", None, raising=False)
+    (tmp_path / "applications").mkdir()
+    args = _make_args(template="applications/template", dryrun=True)
+    create.handle_create(fake_cli, args)
+
+    captured = capsys.readouterr().out
+    assert "holoscan_version" not in captured
+
+
 def test_module_template_prompts_for_directory_when_omitted(
     fake_cli, tmp_path, capsys, monkeypatch
 ):

--- a/tests/unit/test_create_module.py
+++ b/tests/unit/test_create_module.py
@@ -90,9 +90,7 @@ def test_dryrun_application_template_uses_slug_output_folder(fake_cli, tmp_path,
     assert "applications/CMakeLists.txt" in captured
 
 
-def test_dryrun_omits_holoscan_version_when_not_configured(
-    fake_cli, tmp_path, capsys, monkeypatch
-):
+def test_dryrun_omits_holoscan_version_when_not_configured(fake_cli, tmp_path, capsys, monkeypatch):
     monkeypatch.setattr(create.HoloscanContainer, "BASE_SDK_VERSION", None, raising=False)
     (tmp_path / "applications").mkdir()
     args = _make_args(template="applications/template", dryrun=True)

--- a/tests/unit/test_sdk_utils.py
+++ b/tests/unit/test_sdk_utils.py
@@ -87,6 +87,7 @@ def test_get_cuda_tag_handles_sdk_and_cuda_matrix(monkeypatch):
 
     assert sdk.get_cuda_tag(sdk_version="3.6.0") == "igpu"
     assert sdk.get_cuda_tag(sdk_version="3.6.1") == "cuda13-dgpu"
+    assert sdk.get_cuda_tag(None) == "cuda12-igpu"
     assert sdk.get_cuda_tag(None, sdk_version="4.2.0") == "cuda12-igpu"
     assert sdk.get_cuda_tag("13", sdk_version="4.2.0") == "cuda13"
     assert sdk.get_cuda_tag("14", sdk_version="4.2.0") == "cuda14-igpu"


### PR DESCRIPTION
## Summary
- Document the SDK-aligned `holoscan-cli` versioning policy in the public README.
- Remove the hard-coded default Holoscan SDK base version from container defaults.
- Require an explicit base image or configured base SDK version before deriving a default Holoscan SDK base image.

## Test plan
- `python -m pytest tests/unit/test_container_core.py tests/unit/test_sdk_utils.py tests/unit/test_create_module.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Base SDK version is now optional; CLI omits SDK version from generated image tags and templates when not configured.
  * Improved container base-image selection with clearer fallback rules and user-facing guidance when no default is available.

* **Documentation**
  * Added "Versioning" section to README explaining SDK alignment and base-image configuration and fallbacks.

* **Tests**
  * Added unit tests covering image/tag behavior, template generation, and build-arg assembly when SDK is unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->