### PR TITLE
Address #177 review comments: harden image-template formatting + base-image docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,28 +63,39 @@ release line, for example `holoscan-cli==4.4.1` before the next SDK-aligned
 `4.5.0` release.
 
 Version alignment does not imply that the CLI selects, installs, or requires a
-matching Holoscan SDK runtime or container base image. For container builds,
-choose the base image explicitly with `--base-img` or configure one in the
-environment:
+matching Holoscan SDK runtime or container base image. For container builds, the
+base image can be set with the CLI when your component's Dockerfile is configured
+with `FROM ${BASE_IMAGE}`, using any of the methods below:
 
-```bash
-export HOLOSCAN_CLI_BASE_IMAGE=nvcr.io/nvidia/clara-holoscan/holoscan:v4.4.0-cuda13
-holoscan build-container my_app
-```
+1. Pass the image to the `--base-img` flag:
 
-Wrapper repos can also configure the Holoscan SDK container repository and SDK
-version separately:
+   ```bash
+   holoscan build-container my_app --base-img nvcr.io/nvidia/clara-holoscan/holoscan:v4.4.0-cuda13
+   ```
 
-```bash
-export HOLOSCAN_CLI_BASE_IMAGE=nvcr.io/nvidia/clara-holoscan/holoscan
-export HOLOSCAN_CLI_BASE_SDK_VERSION=4.4.0
-holoscan build-container my_app
-```
+2. Set the `HOLOSCAN_CLI_BASE_IMAGE` environment variable to a fully qualified
+   image path:
 
-With the default CUDA selection, that derives the full base image string
-`nvcr.io/nvidia/clara-holoscan/holoscan:v4.4.0-cuda13`. If neither an explicit
-base image tag nor a base SDK version is configured, the CLI asks for a base
-image instead of inferring one from its own package version.
+   ```bash
+   export HOLOSCAN_CLI_BASE_IMAGE=nvcr.io/nvidia/clara-holoscan/holoscan:v4.4.0-cuda13
+   holoscan build-container my_app
+   ```
+
+3. Set `HOLOSCAN_CLI_BASE_IMAGE` to an image repository (no tag) and
+   `HOLOSCAN_CLI_BASE_SDK_VERSION` to a Holoscan semantic version. The base image
+   then resolves to
+   `$HOLOSCAN_CLI_BASE_IMAGE:v$HOLOSCAN_CLI_BASE_SDK_VERSION-$CUDA_TAG`, with the
+   CUDA tag chosen dynamically from your host environment:
+
+   ```bash
+   export HOLOSCAN_CLI_BASE_IMAGE=nvcr.io/nvidia/clara-holoscan/holoscan
+   export HOLOSCAN_CLI_BASE_SDK_VERSION=4.4.0
+   # Resolves to nvcr.io/nvidia/clara-holoscan/holoscan:v4.4.0-cuda13 on hosts with NVIDIA drivers >= 580
+   holoscan build-container my_app
+   ```
+
+If none of these is configured, the CLI asks for a base image instead of
+inferring one from its own package version.
 
 ## Build from source
 

--- a/src/holoscan_cli/container/core.py
+++ b/src/holoscan_cli/container/core.py
@@ -21,6 +21,7 @@ import shlex
 import shutil
 import signal
 import stat
+import string
 import subprocess
 import sys
 import tempfile
@@ -122,24 +123,48 @@ class HoloscanContainer:
 
     @classmethod
     def _format_image_template(cls, template: str, **values: Optional[str]) -> str:
-        if "{sdk_version" in template and not values.get("sdk_version"):
+        """Render an image-name template, failing closed on bad configuration.
+
+        The ``HOLOSCAN_CLI_*_IMAGE_FORMAT`` templates are public configuration,
+        so a mistyped or unset placeholder must surface as a CLI ``fatal(...)``
+        instead of a raw ``KeyError`` / ``ValueError`` traceback. Parsing the
+        referenced fields (rather than a substring check) also keeps escaped
+        braces such as ``{{sdk_version}}`` from being mistaken for a real
+        ``sdk_version`` placeholder.
+        """
+        fields = {name for _, name, _, _ in string.Formatter().parse(template) if name}
+        unknown = fields - set(values)
+        if unknown:
             fatal(
-                "Image format references sdk_version, but HOLOSCAN_CLI_BASE_SDK_VERSION "
-                "is not set."
+                f"Image format {template!r} references unknown field(s): "
+                f"{', '.join(sorted(unknown))}."
             )
-        return template.format(**values)
+        missing = sorted(name for name in fields if not values.get(name))
+        if missing:
+            fatal(
+                f"Image format {template!r} requires value(s) that are not set: "
+                f"{', '.join(missing)} (e.g. set HOLOSCAN_CLI_BASE_SDK_VERSION for "
+                "sdk_version)."
+            )
+        try:
+            return template.format(**values)
+        except (KeyError, IndexError, ValueError) as exc:
+            fatal(f"Invalid image format template {template!r}: {exc}")
 
     @classmethod
     def default_base_image(cls, cuda_version: Optional[Union[str, int]] = None) -> str:
-        cuda_tag = get_cuda_tag(cuda_version, cls.BASE_SDK_VERSION)
+        # ``cuda_tag`` is resolved lazily: computing it probes the host GPU /
+        # driver (and can emit a warning), so it must not run on the branches
+        # that return an explicit image or fatal without ever using it.
         if cls.BASE_IMAGE_FORMAT:
             return cls._format_image_template(
                 cls.BASE_IMAGE_FORMAT,
                 base_image=cls.BASE_IMAGE_NAME,
                 sdk_version=cls.BASE_SDK_VERSION,
-                cuda_tag=cuda_tag,
+                cuda_tag=get_cuda_tag(cuda_version, cls.BASE_SDK_VERSION),
             )
         if cls.BASE_SDK_VERSION:
+            cuda_tag = get_cuda_tag(cuda_version, cls.BASE_SDK_VERSION)
             return f"{cls.BASE_IMAGE_NAME}:v{cls.BASE_SDK_VERSION}-{cuda_tag}"
         if cls.BASE_IMAGE_NAME != cls.DEFAULT_BASE_IMAGE_NAME:
             return cls.BASE_IMAGE_NAME

--- a/tests/unit/test_container_core.py
+++ b/tests/unit/test_container_core.py
@@ -142,6 +142,53 @@ def test_default_base_image_uses_explicit_base_image_without_sdk_version(tmp_pat
     assert c.default_base_image() == "example.com/base:tag"
 
 
+def test_default_base_image_does_not_probe_host_when_unconfigured(tmp_path, monkeypatch):
+    """When nothing is configured the method must fatal *without* probing the
+    host GPU. Computing ``cuda_tag`` eagerly used to emit a spurious driver
+    warning before the fatal."""
+    monkeypatch.setattr(HoloscanContainer, "BASE_SDK_VERSION", None, raising=False)
+    monkeypatch.setattr(HoloscanContainer, "BASE_IMAGE_FORMAT", None, raising=False)
+
+    def _boom(*_args, **_kwargs):
+        raise AssertionError("cuda_tag must not be computed on the fatal path")
+
+    monkeypatch.setattr(container_core, "get_cuda_tag", _boom)
+    c = _stub_container(tmp_path, project_metadata=None)
+
+    with pytest.raises(SystemExit):
+        c.default_base_image()
+
+
+# ---- _format_image_template validation --------------------------------------
+
+
+def test_format_image_template_fatals_on_unknown_field():
+    """A mistyped placeholder is rejected with a fatal, not a raw KeyError."""
+    with pytest.raises(SystemExit):
+        HoloscanContainer._format_image_template("{bogus}", base_image="x")
+
+
+def test_format_image_template_fatals_on_missing_value():
+    """A referenced field whose value is unset (e.g. sdk_version) fatals."""
+    with pytest.raises(SystemExit):
+        HoloscanContainer._format_image_template(
+            "{base_image}:v{sdk_version}-{cuda_tag}",
+            base_image="x",
+            sdk_version=None,
+            cuda_tag="cuda13",
+        )
+
+
+def test_format_image_template_allows_escaped_braces():
+    """Escaped ``{{...}}`` is a literal, not an ``sdk_version`` placeholder, so it
+    must not trigger the missing-value fatal (regression for the old substring
+    check)."""
+    assert (
+        HoloscanContainer._format_image_template("{base_image}:{{sdk_version}}", base_image="x")
+        == "x:{sdk_version}"
+    )
+
+
 def test_image_name_uses_project_tag_when_dockerfile_is_overridden(tmp_path, monkeypatch):
     """A project-specific Dockerfile must produce a project-tagged image
     even when ``--img`` is not supplied. Dockerfile detection is via

--- a/tests/unit/test_sdk_utils.py
+++ b/tests/unit/test_sdk_utils.py
@@ -82,6 +82,9 @@ def test_get_default_cuda_version_falls_back_without_nvidia_smi(monkeypatch, cap
 
 
 def test_get_cuda_tag_handles_sdk_and_cuda_matrix(monkeypatch):
+    # Host probes are stubbed so the matrix is deterministic: the host GPU is
+    # pinned to igpu and the auto-detected CUDA version to 12. That is why a
+    # ``None`` cuda_version (auto-detect) resolves to an igpu tag at CUDA 12.
     monkeypatch.setattr(sdk, "get_host_gpu", lambda: "igpu")
     monkeypatch.setattr(sdk, "get_default_cuda_version", lambda: "12")
 


### PR DESCRIPTION
Follow-up to #177 (merged), addressing its review comments.

## Changes

**`container/core.py`**
- `_format_image_template`: parse the `HOLOSCAN_CLI_*_IMAGE_FORMAT` placeholders with `string.Formatter` and `fatal()` on unknown/missing fields or an invalid template, instead of letting a mistyped or unset placeholder raise a raw `KeyError`/`ValueError` traceback. Parsing the fields (rather than a substring check) also fixes `"{sdk_version" in template` misfiring on escaped `{{sdk_version}}`. — _coderabbitai, Copilot_
- `default_base_image`: compute `cuda_tag` lazily so the host GPU/driver probe (and its warning) no longer runs on the branches that return an explicit image or `fatal()` without using it. — _Copilot_

**`README.md`**
- Rewrite the base-image configuration section into three explicit methods (`--base-img` flag, fully-qualified `HOLOSCAN_CLI_BASE_IMAGE`, or repository + `HOLOSCAN_CLI_BASE_SDK_VERSION`). — _agirault_

**tests**
- New `test_container_core.py` cases for the `_format_image_template` validation paths and the no-host-probe `fatal` path in `default_base_image`.
- Clarifying comment in `test_get_cuda_tag_handles_sdk_and_cuda_matrix` explaining the stubbed host probes (why a `None` cuda_version resolves to an igpu tag). — _tbirdso_

## Testing
- `black --check` + `isort --check` clean; `pytest tests/unit` green (the wheel-install console-script test requires an installed dist, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that `holoscan-cli` SDK-aligned release versions don’t require a matching Holoscan SDK runtime or container base image.
  * Expanded base image configuration guidance, including `--base-img`, `HOLOSCAN_CLI_BASE_IMAGE` (with optional `HOLOSCAN_CLI_BASE_SDK_VERSION` for derived tags), and updated unconfigured prompting behavior.
* **Bug Fixes**
  * Improved base image template validation: unknown placeholders, missing required values, and invalid formatting now fail with clear errors; escaped braces are treated as literal text.
* **Tests**
  * Added unit coverage for base image naming/template validation and safer CUDA-tag behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->