### PR TITLE
Sync post-consolidation HoloHub CLI changes (#1576, #1582, #1587, #1596)

### DIFF
--- a/src/holoscan_cli/commands/build.py
+++ b/src/holoscan_cli/commands/build.py
@@ -31,7 +31,13 @@ from typing import Optional
 
 from holoscan_cli.commands.registry import help_for
 from holoscan_cli.metadata.utils import normalize_language
+from holoscan_cli.utils.cmake_manifest import write_external_operators_manifest
 from holoscan_cli.utils.docker import get_entrypoint_command_args
+from holoscan_cli.utils.external_resolver import (
+    merge_deps,
+    parse_module_dependencies,
+    parse_module_sites,
+)
 from holoscan_cli.utils.holohub import (
     build_holohub_path_mapping,
     check_skip_builds,
@@ -250,10 +256,10 @@ def build_project_locally(
     build_dir = cli.DEFAULT_BUILD_PARENT_DIR / project_name
     build_dir.mkdir(parents=True, exist_ok=True)
 
-    # Prepare environment with extra env vars
+    # Prepare environment with extra env vars first so that HOLOSCAN_CLI_LOCAL_*
+    # overrides from the mode's env block are visible to the module resolvers.
     build_env = os.environ.copy()
     if extra_env:
-        # Build path mapping
         path_mapping = build_holohub_path_mapping(
             holohub_root=cli.HOLOHUB_ROOT,
             project_data=project_data,
@@ -263,6 +269,25 @@ def build_project_locally(
             verbose=dryrun,
         )
         update_env(build_env, extra_env, path_mapping, verbose=dryrun)
+
+    # Write external_operators_manifest.cmake before cmake configure so that
+    # CMakeLists.txt:include(…OPTIONAL) picks it up and FetchContent_MakeAvailable
+    # is called for any external modules whose operators end up enabled.
+    metadata_path = Path(project_data.get("source_folder", "")) / "metadata.json"
+    sites_deps = parse_module_sites(
+        cli.HOLOHUB_ROOT / "modules" / "module-sites.json",
+        source_root=cli.HOLOHUB_ROOT,
+        env=build_env,
+    )
+    project_deps = parse_module_dependencies(
+        metadata_path, source_root=cli.HOLOHUB_ROOT, env=build_env
+    )
+    ext_deps = merge_deps(sites_deps, project_deps)
+    manifest_path = build_dir / "external_operators_manifest.cmake"
+    if dryrun:
+        info(f"[dryrun] Would write {manifest_path}")
+    else:
+        write_external_operators_manifest(ext_deps, manifest_path)
 
     proj_prefix = determine_project_prefix(project_type)
     cmake_args = [
@@ -350,7 +375,7 @@ def build_project_locally(
         )
 
     if configure_args:
-        cmake_args.extend(configure_args)
+        cmake_args.extend(os.path.expandvars(arg) for arg in configure_args)
 
     run_command(cmake_args, dry_run=dryrun, env=build_env)
 

--- a/src/holoscan_cli/commands/build.py
+++ b/src/holoscan_cli/commands/build.py
@@ -273,14 +273,21 @@ def build_project_locally(
     # Write external_operators_manifest.cmake before cmake configure so that
     # CMakeLists.txt:include(…OPTIONAL) picks it up and FetchContent_MakeAvailable
     # is called for any external modules whose operators end up enabled.
-    metadata_path = Path(project_data.get("source_folder", "")) / "metadata.json"
     sites_deps = parse_module_sites(
         cli.HOLOHUB_ROOT / "modules" / "module-sites.json",
         source_root=cli.HOLOHUB_ROOT,
         env=build_env,
     )
-    project_deps = parse_module_dependencies(
-        metadata_path, source_root=cli.HOLOHUB_ROOT, env=build_env
+    # Only parse the project's own metadata.json when we know where it lives —
+    # an empty source_folder would otherwise resolve to a cwd-relative
+    # "metadata.json" and pick up an unrelated file.
+    source_folder = project_data.get("source_folder")
+    project_deps = (
+        parse_module_dependencies(
+            Path(source_folder) / "metadata.json", source_root=cli.HOLOHUB_ROOT, env=build_env
+        )
+        if source_folder
+        else []
     )
     ext_deps = merge_deps(sites_deps, project_deps)
     manifest_path = build_dir / "external_operators_manifest.cmake"

--- a/src/holoscan_cli/commands/info.py
+++ b/src/holoscan_cli/commands/info.py
@@ -75,7 +75,11 @@ def handle_list(cli, _args: argparse.Namespace) -> None:
                 language = ", ".join(language)
             language = f"({language})" if language else ""
             if project_type == "module":
-                operators = metadata.get("operators", [])
+                operators = (
+                    metadata.get("operator_names")
+                    or metadata.get("operators")
+                    or metadata.get("subprojects", {}).get("operators", [])
+                )
                 ops = f" [{', '.join(operators)}]" if operators else ""
                 print(f'{project["project_name"]} {language}{ops}')
             else:

--- a/src/holoscan_cli/commands/package.py
+++ b/src/holoscan_cli/commands/package.py
@@ -105,7 +105,6 @@ def _resolve_module_project(cli, project_arg: Optional[str], language: Optional[
                 "project_name": module_name,
                 "source_folder": str(cwd),
                 "metadata": module,
-                "standalone_module": True,
             }
 
     if project_arg:
@@ -116,9 +115,7 @@ def _resolve_module_project(cli, project_arg: Optional[str], language: Optional[
                 f"'holoscan package' only supports modules; "
                 f"'{project_arg}' is type '{project_type}'"
             )
-        project_data = dict(project_data)
-        project_data.setdefault("standalone_module", False)
-        return project_data
+        return dict(project_data)
 
     fatal(
         "No project specified and no ./metadata.json found in the current working directory. "

--- a/src/holoscan_cli/commands/package.py
+++ b/src/holoscan_cli/commands/package.py
@@ -65,6 +65,9 @@ def register_package_parser(
     )
     parser.add_argument("--language", choices=["cpp", "python"], default=None)
     parser.add_argument("--verbose", action="store_true")
+    parser.add_argument(
+        "--no-docker-build", action="store_true", help="Skip building the container"
+    )
     parser.add_argument("--dryrun", action="store_true", default=False)
     parser.set_defaults(func=lambda args: handle_package(cli, args))
     return parser
@@ -121,13 +124,6 @@ def _resolve_module_project(cli, project_arg: Optional[str], language: Optional[
         "No project specified and no ./metadata.json found in the current working directory. "
         "Run from a module project root, or pass a module name as the first argument."
     )
-
-
-def _module_package_flag(project_data: dict, package_slug: str) -> str:
-    """Return the CMake flag that enables packaging for this module shape."""
-    if project_data.get("standalone_module"):
-        return f"-DPKG_{package_slug}=ON"
-    return f"-DMODULE_{package_slug}=ON"
 
 
 def handle_package(cli, args: argparse.Namespace) -> None:
@@ -231,8 +227,17 @@ def _package_locally(cli, args: argparse.Namespace, project_data: dict) -> None:
             f"-DPython3_ROOT_DIR={os.path.dirname(os.path.dirname(sys.executable))}",
             f"-DCMAKE_BUILD_TYPE={build_type}",
             f"-DCMAKE_PREFIX_PATH={cli.DEFAULT_SDK_DIR}/lib",
+            # BUILD_ALL=OFF keeps unrelated subprojects out of this package.
+            # MODULE_<slug>=ON enters the module subdir for in-tree HoloHub
+            # builds (modules/CMakeLists.txt gates add_holohub_module() on it);
+            # PKG_<slug>=ON then activates the target's add_holohub_package()
+            # cascade, which FORCEs its OP_/APP_/EXT_ deps ON and emits the
+            # CPack config. In-tree packaging needs BOTH. For standalone module
+            # repos (where add_holohub_module() never runs because the module is
+            # the top-level project) MODULE_<slug>=ON is a harmless unused entry.
             "-DBUILD_ALL=OFF",
-            _module_package_flag(project_data, package_slug),
+            f"-DMODULE_{package_slug}=ON",
+            f"-DPKG_{package_slug}=ON",
         ]
         if shutil.which("ninja"):
             cmake_args.extend(["-G", "Ninja"])

--- a/src/holoscan_cli/metadata/module.schema.json
+++ b/src/holoscan_cli/metadata/module.schema.json
@@ -261,12 +261,12 @@
           },
           "additionalProperties": false
         },
-        "operators": {
+        "operator_names": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Operators this module supplies. Authoritative self-advertisement; consumers may mirror these in their dependencies[].provides_operators to enable lazy fetch. The resolver compares the two lists after fetch and warns on drift."
+          "description": "Operator class names this module supplies (e.g. GstVideoRecorderOp). Cosmetic/display field — does not drive CMake flags. For build-system gating use subprojects.operators."
         },
         "dependencies": {
           "type": "array",

--- a/src/holoscan_cli/utils/external_resolver.py
+++ b/src/holoscan_cli/utils/external_resolver.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
@@ -93,15 +94,17 @@ def _module_dependencies_raw(metadata: dict) -> list[dict]:
 def parse_module_dependencies(
     metadata_path: Path,
     source_root: Optional[Path] = None,
+    env: Optional[dict] = None,
 ) -> list[ModuleDep]:
     """Parse a metadata.json's external module dependency list into
     :class:`ModuleDep` records.
 
     Honors ``HOLOSCAN_CLI_LOCAL_<NAME>`` env-var overrides by populating
-    ``override_path``. When ``source_root`` is provided, dependencies with no
-    ``source`` block are checked against ``source_root/modules/<name>/``. If a
-    metadata.json exists there, the dependency is treated as an in-tree module
-    instead of an error.
+    ``override_path``. Pass ``env`` to override the process environment for
+    override lookups (defaults to ``os.environ``). When ``source_root`` is
+    provided, dependencies with no ``source`` block are checked against
+    ``source_root/modules/<name>/``. If a metadata.json exists there, the
+    dependency is treated as an in-tree module instead of an error.
 
     Does not fetch anything. A missing metadata.json is
     treated as "no external deps" rather than an error — unifies the
@@ -114,6 +117,7 @@ def parse_module_dependencies(
         return []
     except json.JSONDecodeError as e:
         raise ValueError(f"Malformed JSON in {metadata_path}: {e}") from e
+    _env = env if env is not None else os.environ
     raw = _module_dependencies_raw(metadata)
     out: list[ModuleDep] = []
     for entry in raw:
@@ -123,7 +127,7 @@ def parse_module_dependencies(
         source = entry.get("source") or {}
         provides = list(entry.get("provides_operators") or [])
 
-        override = os.environ.get(_override_env_name(name))
+        override = _env.get(_override_env_name(name))
         override_path: Optional[Path] = None
         if override:
             p = Path(override).expanduser().resolve()
@@ -158,13 +162,11 @@ def parse_module_dependencies(
                     f"at modules/{name}/metadata.json for in-tree modules."
                 )
             if not _ref_is_immutable(ref):
-                import sys as _sys
-
                 print(
                     f"WARNING: dependency '{name}' pinned to ref '{ref}', which "
                     "is not a 40-char commit SHA. Tags and branches are mutable; "
                     "consider pinning to an immutable SHA for reproducible builds.",
-                    file=_sys.stderr,
+                    file=sys.stderr,
                 )
 
         out.append(
@@ -177,3 +179,147 @@ def parse_module_dependencies(
             )
         )
     return out
+
+
+def parse_module_sites(
+    sites_path: Path,
+    source_root: Optional[Path] = None,
+    env: Optional[dict] = None,
+) -> list[ModuleDep]:
+    """Parse ``modules/module-sites.json`` into :class:`ModuleDep` records.
+
+    External entries (url + ref present) become fetchable deps;
+    ``provides_operators`` is read directly from the site entry and is
+    authoritative. Project metadata serves only as a fallback via
+    :func:`merge_deps`. In-tree entries (no url) resolve to ``is_internal=True``
+    when ``source_root/modules/<name>/metadata.json`` exists; entries with
+    neither a url nor an in-tree path are silently skipped.
+
+    An entry with url but no ref (or ref but no url) raises ``ValueError`` —
+    partial source specs hide typos and should fail loudly.
+
+    Honors ``HOLOSCAN_CLI_LOCAL_<NAME>`` overrides with the same semantics as
+    :func:`parse_module_dependencies`. Pass ``env`` to override the process
+    environment for override lookups (defaults to ``os.environ``). A missing
+    ``sites_path`` is treated as no module sites rather than an error.
+    """
+    try:
+        with sites_path.open() as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        return []
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Malformed JSON in {sites_path}: {e}") from e
+
+    _env = env if env is not None else os.environ
+    out: list[ModuleDep] = []
+    for entry in data.get("modules") or []:
+        name = entry.get("name")
+        if not name:
+            continue
+
+        override = _env.get(_override_env_name(name))
+        override_path: Optional[Path] = None
+        if override:
+            p = Path(override).expanduser().resolve()
+            if not (p / "metadata.json").exists():
+                raise FileNotFoundError(
+                    f"{_override_env_name(name)}={override} does not contain a "
+                    "metadata.json — point it at the root of a Holoscan Module "
+                    "project."
+                )
+            override_path = p
+
+        url = entry.get("url")
+        ref = entry.get("ref")
+
+        provides = list(entry.get("provides_operators") or [])
+
+        if bool(url) != bool(ref):
+            raise ValueError(
+                f"module-sites entry '{name}' must declare both 'url' and 'ref' "
+                "together, or neither for an in-tree/local-only module."
+            )
+
+        if url and ref:
+            if not _ref_is_immutable(ref):
+                print(
+                    f"WARNING: module-sites entry '{name}' pinned to ref '{ref}', which "
+                    "is not a 40-char commit SHA. Tags and branches are mutable; "
+                    "consider pinning to an immutable SHA for reproducible builds.",
+                    file=sys.stderr,
+                )
+            out.append(
+                ModuleDep(
+                    name=name,
+                    git_url=url,
+                    ref=ref,
+                    provides_operators=provides,
+                    override_path=override_path,
+                )
+            )
+        elif override_path is not None:
+            # No canonical url but a local override is active — treat as external.
+            out.append(
+                ModuleDep(name=name, provides_operators=provides, override_path=override_path)
+            )
+        elif source_root is not None:
+            in_tree_path = source_root / "modules" / name
+            if (in_tree_path / "metadata.json").exists():
+                out.append(
+                    ModuleDep(
+                        name=name,
+                        provides_operators=provides,
+                        override_path=in_tree_path,
+                        is_internal=True,
+                    )
+                )
+            # else: not external and not in-tree — skip
+
+    return out
+
+
+def merge_deps(
+    sites_deps: list[ModuleDep],
+    project_deps: list[ModuleDep],
+) -> list[ModuleDep]:
+    """Merge module-sites deps with project-specific deps.
+
+    Sites supply canonical git coordinates and own ``provides_operators``
+    authoritatively; project deps provide ``override_path`` and serve as a
+    fallback source for ``provides_operators`` when the site entry has none.
+    For a module present in both lists the merged record takes the site's
+    git_url/ref and is_internal classification, but the project dep's
+    override_path. Modules only in ``project_deps`` are appended after all site
+    entries (preserving sites order first).
+    """
+    project_by_name = {d.name: d for d in project_deps}
+    seen: set[str] = set()
+    result: list[ModuleDep] = []
+
+    for sd in sites_deps:
+        pd = project_by_name.get(sd.name)
+        if pd is not None:
+            # Sites owns the canonical git coords and is_internal classification.
+            # Sites also owns provides_operators (authoritative module metadata);
+            # project ops are used only as a fallback when sites has none.
+            ops = sd.provides_operators if sd.provides_operators else pd.provides_operators
+            result.append(
+                ModuleDep(
+                    name=sd.name,
+                    git_url=sd.git_url,
+                    ref=sd.ref,
+                    provides_operators=ops,
+                    override_path=pd.override_path,
+                    is_internal=sd.is_internal,
+                )
+            )
+        else:
+            result.append(sd)
+        seen.add(sd.name)
+
+    for pd in project_deps:
+        if pd.name not in seen:
+            result.append(pd)
+
+    return result

--- a/tests/fixtures/module_metadata/valid/module_advertises_operators.json
+++ b/tests/fixtures/module_metadata/valid/module_advertises_operators.json
@@ -1,7 +1,7 @@
 {
     "module": {
         "name": "module_advertises_operators",
-        "description": "Module that advertises its operators via the operators field.",
+        "description": "Module that advertises its operators via the operator_names field.",
         "authors": [{ "name": "NVIDIA", "affiliation": "NVIDIA" }],
         "version": "1.2.3",
         "language": ["Python", "C++"],
@@ -11,6 +11,6 @@
             "minimum_required_version": "4.0.0",
             "tested_versions": ["4.2.0"]
         },
-        "operators": ["foo_op", "bar_op"]
+        "operator_names": ["foo_op", "bar_op"]
     }
 }

--- a/tests/unit/test_cli_parser.py
+++ b/tests/unit/test_cli_parser.py
@@ -96,6 +96,16 @@ def test_each_subcommand_accepts_help_flag(cli, command, capsys):
     assert capsys.readouterr().out  # argparse printed help text
 
 
+def test_package_accepts_no_docker_build_flag(cli):
+    """``holoscan package`` exposes --no-docker-build like the other
+    container-first commands (holohub#1596)."""
+    args = cli.parser.parse_args(["package", "fixture", "--no-docker-build"])
+    assert args.no_docker_build is True
+    # Default stays False so check_skip_builds doesn't skip unexpectedly.
+    args = cli.parser.parse_args(["package", "fixture"])
+    assert args.no_docker_build is False
+
+
 def _subparser_help_strings(parser):
     """Return ``{command_name: help}`` recorded on the parser's subparsers action.
 

--- a/tests/unit/test_command_registry.py
+++ b/tests/unit/test_command_registry.py
@@ -96,7 +96,10 @@ def test_list_prints_modules_with_languages_and_operators(capsys):
             {
                 "project_type": "module",
                 "project_name": "holoscan-gstreamer",
-                "metadata": {"language": ["C++", "Python"], "operators": ["gstreamer"]},
+                "metadata": {
+                    "language": ["C++", "Python"],
+                    "operator_names": ["GstVideoRecorderOp"],
+                },
             }
         ]
     )
@@ -105,4 +108,30 @@ def test_list_prints_modules_with_languages_and_operators(capsys):
 
     out = capsys.readouterr().out
     assert "== MODULES" in out
-    assert "holoscan-gstreamer (C++, Python) [gstreamer]" in out
+    assert "holoscan-gstreamer (C++, Python) [GstVideoRecorderOp]" in out
+
+
+@pytest.mark.parametrize(
+    "metadata, expected",
+    [
+        ({"operator_names": ["GstVideoRecorderOp"]}, "[GstVideoRecorderOp]"),
+        # Falls back to the legacy top-level ``operators`` field …
+        ({"operators": ["gstreamer"]}, "[gstreamer]"),
+        # … then to ``subprojects.operators`` (the build-gating list).
+        ({"subprojects": {"operators": ["gstreamer"]}}, "[gstreamer]"),
+    ],
+)
+def test_list_module_operator_display_fallbacks(capsys, metadata, expected):
+    cli = SimpleNamespace(
+        projects=[
+            {
+                "project_type": "module",
+                "project_name": "holoscan-gstreamer",
+                "metadata": metadata,
+            }
+        ]
+    )
+
+    info.handle_list(cli, SimpleNamespace())
+
+    assert expected in capsys.readouterr().out

--- a/tests/unit/test_external_resolver.py
+++ b/tests/unit/test_external_resolver.py
@@ -32,7 +32,9 @@ from holoscan_cli.utils.external_resolver import (
     ModuleDep,
     _override_env_name,
     _ref_is_immutable,
+    merge_deps,
     parse_module_dependencies,
+    parse_module_sites,
 )
 
 FULL_SHA = "0" * 40
@@ -405,3 +407,113 @@ def test_in_tree_lookup_is_opt_in(tmp_path, _clean_local_override_env):
 
     with pytest.raises(ValueError, match="missing source.git_url"):
         parse_module_dependencies(meta)
+
+
+# ---- module-sites (parse_module_sites) ---------------------------------------
+
+
+def _write_sites(tmp_path, modules: list):
+    p = tmp_path / "module-sites.json"
+    p.write_text(json.dumps({"modules": modules}), encoding="utf-8")
+    return p
+
+
+def test_module_sites_external_entry_becomes_fetchable(tmp_path, _clean_local_override_env):
+    sites = _write_sites(
+        tmp_path,
+        [
+            {
+                "name": "holoscan-deltacast",
+                "url": "https://github.com/deltacasttv/holoscan-modules",
+                "ref": FULL_SHA,
+                "provides_operators": ["videomaster_source"],
+            }
+        ],
+    )
+
+    deps = parse_module_sites(sites)
+
+    assert len(deps) == 1
+    assert deps[0].name == "holoscan-deltacast"
+    assert deps[0].git_url == "https://github.com/deltacasttv/holoscan-modules"
+    assert deps[0].ref == FULL_SHA
+    assert deps[0].provides_operators == ["videomaster_source"]
+    assert deps[0].is_internal is False
+
+
+def test_module_sites_missing_file_returns_empty(tmp_path):
+    assert parse_module_sites(tmp_path / "nope.json") == []
+
+
+def test_module_sites_partial_source_spec_raises(tmp_path, _clean_local_override_env):
+    sites = _write_sites(tmp_path, [{"name": "broken", "url": "https://x/y"}])
+    with pytest.raises(ValueError, match="both 'url' and 'ref'"):
+        parse_module_sites(sites)
+
+
+def test_module_sites_in_tree_entry_when_present(tmp_path, _clean_local_override_env):
+    source_root = tmp_path / "source"
+    _make_in_tree_module(source_root, "holoscan-gstreamer")
+    sites = _write_sites(tmp_path, [{"name": "holoscan-gstreamer"}])
+
+    deps = parse_module_sites(sites, source_root=source_root)
+
+    assert len(deps) == 1
+    assert deps[0].is_internal is True
+    assert deps[0].git_url is None
+
+
+def test_module_sites_local_only_entry_skipped_without_in_tree(tmp_path, _clean_local_override_env):
+    # No url/ref and no matching modules/<name>/ -> silently skipped.
+    sites = _write_sites(tmp_path, [{"name": "ghost"}])
+    assert parse_module_sites(sites, source_root=tmp_path / "source") == []
+
+
+def test_module_sites_local_override_wins(tmp_path, monkeypatch, _clean_local_override_env):
+    override_dir = tmp_path / "local_dc"
+    override_dir.mkdir()
+    (override_dir / "metadata.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("HOLOSCAN_CLI_LOCAL_HOLOSCAN_DELTACAST", str(override_dir))
+    sites = _write_sites(tmp_path, [{"name": "holoscan-deltacast"}])
+
+    deps = parse_module_sites(sites, source_root=tmp_path / "source")
+
+    assert len(deps) == 1
+    assert deps[0].override_path == override_dir.resolve()
+
+
+# ---- merge_deps --------------------------------------------------------------
+
+
+def test_merge_deps_site_owns_coords_project_supplies_override():
+    site = ModuleDep(name="m", git_url="https://x/y", ref=FULL_SHA)
+    proj = ModuleDep(
+        name="m", provides_operators=["op_a"], override_path="/local/m"  # type: ignore[arg-type]
+    )
+
+    merged = merge_deps([site], [proj])
+
+    assert len(merged) == 1
+    assert merged[0].git_url == "https://x/y"
+    assert merged[0].ref == FULL_SHA
+    # Site has no provides_operators -> falls back to the project dep's.
+    assert merged[0].provides_operators == ["op_a"]
+    assert merged[0].override_path == "/local/m"
+
+
+def test_merge_deps_site_provides_operators_authoritative():
+    site = ModuleDep(name="m", git_url="https://x/y", ref=FULL_SHA, provides_operators=["site_op"])
+    proj = ModuleDep(name="m", provides_operators=["proj_op"])
+
+    merged = merge_deps([site], [proj])
+
+    assert merged[0].provides_operators == ["site_op"]
+
+
+def test_merge_deps_project_only_modules_appended_after_sites():
+    site = ModuleDep(name="s", git_url="https://x/y", ref=FULL_SHA)
+    proj_only = ModuleDep(name="p", git_url="https://a/b", ref=FULL_SHA)
+
+    merged = merge_deps([site], [proj_only])
+
+    assert [d.name for d in merged] == ["s", "p"]

--- a/tests/unit/test_lifecycle_commands.py
+++ b/tests/unit/test_lifecycle_commands.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 from argparse import Namespace
 
 from holoscan_cli.commands import build as build_cmd
@@ -260,6 +261,47 @@ def test_build_project_locally_module_enables_subprojects_and_sccache(
     assert "-DCMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/sccache" in cmake_args
     assert calls[-1] == ["sccache", "--show-stats"]
     assert "Building module 'holoscan-smoke'" in capsys.readouterr().out
+
+
+def test_build_writes_external_operators_manifest_from_module_sites(tmp_path, monkeypatch):
+    """build_project_locally emits external_operators_manifest.cmake from
+    modules/module-sites.json before configuring CMake (holohub#1587)."""
+    modules_dir = tmp_path / "repo" / "modules"
+    modules_dir.mkdir(parents=True)
+    (modules_dir / "module-sites.json").write_text(
+        json.dumps(
+            {
+                "modules": [
+                    {
+                        "name": "holoscan-deltacast",
+                        "url": "https://github.com/deltacasttv/holoscan-modules",
+                        "ref": "0" * 40,
+                        "provides_operators": ["videomaster_source"],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    app_dir = tmp_path / "repo" / "applications" / "demo"
+    app_dir.mkdir(parents=True)
+    project = {
+        "project_name": "demo",
+        "project_type": "application",
+        "source_folder": app_dir,
+        "metadata": {"language": "python"},
+    }
+    cli = RecordingCLI(tmp_path, project)
+    monkeypatch.setattr(build_cmd, "run_command", lambda cmd, **kwargs: None)
+    monkeypatch.setattr(build_cmd.shutil, "which", lambda name: None)
+
+    build_dir, _ = build_cmd.build_project_locally(cli, "demo", dryrun=False)
+
+    manifest = build_dir / "external_operators_manifest.cmake"
+    assert manifest.exists()
+    content = manifest.read_text(encoding="utf-8")
+    assert "deltacasttv/holoscan-modules" in content
+    assert "videomaster_source" in content
 
 
 def test_handle_build_container_branch_passes_recursive_local_command(tmp_path, monkeypatch):

--- a/tests/unit/test_package_cmd.py
+++ b/tests/unit/test_package_cmd.py
@@ -210,7 +210,6 @@ def test_resolve_module_project_prefers_standalone_cwd_metadata(tmp_path, monkey
         "project_name": "holoscan-smoke",
         "source_folder": str(module_dir),
         "metadata": {"name": "holoscan-smoke", "language": ["Python"]},
-        "standalone_module": True,
     }
 
 
@@ -234,4 +233,3 @@ def test_resolve_module_project_falls_back_to_source_tree_when_cwd_metadata_inva
     )
 
     assert project_data["project_name"] == "test-module-fixture"
-    assert project_data["standalone_module"] is False

--- a/tests/unit/test_package_cmd.py
+++ b/tests/unit/test_package_cmd.py
@@ -72,9 +72,11 @@ def test_package_deb_emits_module_cmake_flag_for_in_tree_module(tmp_path, monkey
     package_cmd.handle_package(cli, _args(project="test-module-fixture", pkg_generator="DEB"))
 
     cmake_args = " ".join(str(a) for a in calls[0])
+    # In-tree packaging needs BOTH MODULE_ (enter the module subdir) and PKG_
+    # (activate the add_holohub_package cascade). See holohub#1582.
     assert "-DMODULE_test_module_fixture=ON" in cmake_args
+    assert "-DPKG_test_module_fixture=ON" in cmake_args
     assert "-DBUILD_ALL=OFF" in cmake_args
-    assert "-DPKG_" not in cmake_args
     assert calls[2][0] == "cpack"
 
 
@@ -95,8 +97,51 @@ def test_package_deb_emits_pkg_flag_for_standalone_module(tmp_path, monkeypatch)
     package_cmd.handle_package(cli, _args(pkg_generator="DEB"))
 
     cmake_args = " ".join(str(a) for a in calls[0])
+    # Both flags are emitted unconditionally (holohub#1582); for a standalone
+    # module repo MODULE_ is a harmless unused cache entry.
     assert "-DPKG_holoscan_smoke=ON" in cmake_args
-    assert "-DMODULE_" not in cmake_args
+    assert "-DMODULE_holoscan_smoke=ON" in cmake_args
+
+
+def test_package_container_honors_no_docker_build_and_cuda(tmp_path, monkeypatch):
+    """Container packaging skips the build for --no-docker-build and forwards
+    --cuda to the container build args (holohub#1596, #1597)."""
+    from unittest.mock import MagicMock
+
+    import holoscan_cli.cli as cli_mod
+
+    monkeypatch.delenv("HOLOSCAN_CLI_BUILD_LOCAL", raising=False)
+    monkeypatch.setenv("HOLOSCAN_CLI_ALWAYS_BUILD", "1")
+
+    project_data = {
+        "project_name": "test-module-fixture",
+        "project_type": "module",
+        "source_folder": tmp_path / "repo" / "modules" / "test-module-fixture",
+        "metadata": {"language": ["Python"]},
+    }
+    cli = _cli(tmp_path, project_data)
+    monkeypatch.setattr(package_cmd, "get_entrypoint_command_args", lambda *a, **k: ("", []))
+    monkeypatch.setattr(cli_mod, "in_container_cli_command", lambda: "holoscan")
+
+    # --no-docker-build -> the container build is skipped, but --cuda is still
+    # applied to the container so the in-container package build uses it.
+    skip_container = MagicMock()
+    skip_container.image_name = "img:tag"
+    cli.make_project_container = lambda project_name, language=None: skip_container
+    package_cmd.handle_package(
+        cli,
+        _args(project="test-module-fixture", local=False, no_docker_build=True, cuda="13"),
+    )
+    skip_container.build.assert_not_called()
+    assert skip_container.cuda_version == "13"
+
+    # Default (build runs) -> --cuda is forwarded to container.build().
+    build_container = MagicMock()
+    build_container.image_name = "img:tag"
+    cli.make_project_container = lambda project_name, language=None: build_container
+    package_cmd.handle_package(cli, _args(project="test-module-fixture", local=False, cuda="13"))
+    build_container.build.assert_called_once()
+    assert build_container.build.call_args.kwargs.get("cuda_version") == "13"
 
 
 def test_package_wheel_invokes_python_build(wheel_module, monkeypatch):


### PR DESCRIPTION
## What

HoloHub's in-tree `utilities/cli` kept evolving after it was consolidated into this repo. [holohub#1583](https://github.com/nvidia-holoscan/holohub/pull/1583) migrates HoloHub onto `holoscan-cli` and deletes the in-tree CLI, so fixes that landed there after the consolidation snapshot are lost unless ported here. This PR ports the relevant ones.

## Ported changes

| HoloHub PR | Change | Here |
| --- | --- | --- |
| [#1576](https://github.com/nvidia-holoscan/holohub/pull/1576) | Rename module `operators` → `operator_names` (display-only) + 3-way `list` fallback | `module.schema.json`, `info.py`, fixture/tests |
| [#1596](https://github.com/nvidia-holoscan/holohub/pull/1596) | Expose `--no-docker-build` on `holoscan package` | `package.py` parser (`handle_package` already honored `check_skip_builds`) |
| [#1582](https://github.com/nvidia-holoscan/holohub/pull/1582) | In-tree module packaging needs **both** `-DMODULE_<slug>=ON` and `-DPKG_<slug>=ON` | `package.py` `_package_locally` emits both |
| [#1587](https://github.com/nvidia-holoscan/holohub/pull/1587) | External module-sites resolution (lazy fetch of external Holoscan Modules, e.g. DELTACAST.TV) | `external_resolver.parse_module_sites`/`merge_deps` + `build.py` writes `external_operators_manifest.cmake` |

[#1597](https://github.com/nvidia-holoscan/holohub/pull/1597) (forwarding `--cuda` from `package` to the container build) was already correct here; a regression test was added.

## Notes

- `#1582` and `#1587` were verified against the HoloHub CMake (`cmake/HoloHubConfigHelpers.cmake` flag gating; the root `CMakeLists.txt` `include(external_operators_manifest.cmake OPTIONAL)` hook).
- A comprehensive flag-level diff of HoloHub `main`'s in-tree CLI vs this repo showed no other missing flags.
- Unit tests added/updated; `black`/`ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Module operator display now falls back across multiple metadata keys so advertised operators reliably appear.
  * Module metadata adds a dedicated cosmetic/display field for operator names (does not affect build gating).

* **New Features**
  * Local build writes an external-operators manifest so optional external/local operators are recognized during configuration.
  * Packaging adds a --no-docker-build option and always emits explicit CMake flags for in-tree module packaging.

* **Tests**
  * Expanded tests for operator display fallbacks, module-site resolution/merging, packaging flags, and manifest generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->