### PR TITLE
fix: restore releases/4.2.0 manifest files on main (hotfix for #182)

### DIFF
--- a/releases/4.2.0/artifacts-cu12.json
+++ b/releases/4.2.0/artifacts-cu12.json
@@ -1,0 +1,31 @@
+{
+  "4.2.0": {
+    "holoscan": {
+      "debian-version": "4.2.0.1-1",
+      "wheel-version": "4.2.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:12.8.1-runtime-ubuntu24.04",
+        "igpu": "nvcr.io/nvidia/l4t-tensorrt:r10.3.0-devel"
+      },
+      "build-images": {
+        "igpu": {
+          "jetson-agx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.2.0-cuda12-igpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.2.0-cuda12-igpu"
+        },
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.2.0-cuda12-dgpu",
+          "igx-orin-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.2.0-cuda12-dgpu",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.2.0-cuda12-dgpu",
+          "clara-agx-devkit": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.2.0-cuda12-dgpu"
+        },
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.2.0-cuda12-dgpu"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-arm64"
+    }
+  }
+}

--- a/releases/4.2.0/artifacts.json
+++ b/releases/4.2.0/artifacts.json
@@ -1,0 +1,25 @@
+{
+  "4.2.0": {
+    "holoscan": {
+      "debian-version": "4.2.0.1-1",
+      "wheel-version": "4.2.0",
+      "base-images": {
+        "dgpu": "nvcr.io/nvidia/cuda:13.0.0-runtime-ubuntu24.04"
+      },
+      "build-images": {
+        "dgpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.2.0-cuda13",
+          "sbsa": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.2.0-cuda13"
+        },
+        "igpu": {},
+        "cpu": {
+          "x64-workstation": "nvcr.io/nvidia/clara-holoscan/holoscan:v4.2.0-cuda13"
+        }
+      }
+    },
+    "health-probes": {
+      "linux/amd64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-amd64",
+      "linux/arm64": "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.38/grpc_health_probe-linux-arm64"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Restores `releases/4.2.0/artifacts-cu12.json` and `releases/4.2.0/artifacts.json` to `main`
- v4.2.0 of holoscan-cli hardcodes a `refs/heads/main` URL to fetch these manifests at runtime; deleting `releases/` from main after the v4.2.0 tag broke `holoscan package` for all existing v4.2.0 installs
- Content recovered verbatim from git history (commit `240d5c6`)

## Test plan

- [ ] Verify `curl https://raw.githubusercontent.com/nvidia-holoscan/holoscan-cli/refs/heads/main/releases/4.2.0/artifacts-cu12.json` returns 200 after merge
- [ ] Verify `curl https://raw.githubusercontent.com/nvidia-holoscan/holoscan-cli/refs/heads/main/releases/4.2.0/artifacts.json` returns 200 after merge
- [ ] Confirm `holoscan package` with a v4.2.0 install no longer fails with "Not Found" on manifest download

## Follow-up

The long-term fix (v4.2.1) should update the default manifest URL to point to a stable, versioned location (e.g., a GitHub Release asset or a tag ref) instead of `refs/heads/main`, so future `releases/` cleanups don't break already-shipped versions.

Fixes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added release 4.2.0 artifact configuration, including container image references and version metadata.
  * Configured support for CUDA 12 and CUDA 13 variants for 4.2.0 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->