### PR TITLE
fix: replace 'holoscan-cli v1' with 'since holoscan v4.3.0' in removed-command errors

### DIFF
--- a/src/holoscan_cli/__main__.py
+++ b/src/holoscan_cli/__main__.py
@@ -54,7 +54,7 @@ REMOVED_COMMANDS: dict[str, str] = {
 }
 
 REMOVED_COMMAND_FOOTER = (
-    "Removed HAP/MAP commands are out of scope for holoscan-cli v1. Pin "
+    "Removed HAP/MAP commands are not available since holoscan v4.3.0. Pin "
     "holoscan-cli<=4.2.0 if you still need that legacy command surface."
 )
 
@@ -179,7 +179,7 @@ def _exit_if_removed_command(argv: list[str]) -> None:
         return
     program = _program_name(argv)
     print(
-        f"Error: '{program} {command}' was removed in holoscan-cli v1 — "
+        f"Error: '{program} {command}' was removed since holoscan v4.3.0 — "
         f"{REMOVED_COMMANDS[command]} is no longer shipped.\n"
         f"{REMOVED_COMMAND_FOOTER}",
         file=sys.stderr,


### PR DESCRIPTION
## Summary

- In `__main__.py`, the error messages shown when a user runs a removed command (e.g. `holoscan nics`) referenced the internal codename "holoscan-cli v1", which is meaningless to end users
- Replaced with the public release version "since holoscan v4.3.0" so the message is self-explanatory

**Before:**
```
Error: 'holoscan nics' was removed in holoscan-cli v1 — the HAP NIC diagnostic command is no longer shipped.
Removed HAP/MAP commands are out of scope for holoscan-cli v1. Pin holoscan-cli<=4.2.0 if you still need that legacy command surface.
```

**After:**
```
Error: 'holoscan nics' was removed since holoscan v4.3.0 — the HAP NIC diagnostic command is no longer shipped.
Removed HAP/MAP commands are not available since holoscan v4.3.0. Pin holoscan-cli<=4.2.0 if you still need that legacy command surface.
```

## Test plan

- [ ] Run `holoscan nics` and confirm the updated error message is printed to stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)