### PR TITLE
fix: port HoloHub Orin GPU detection

### DIFF
--- a/src/holoscan_cli/utils/sdk.py
+++ b/src/holoscan_cli/utils/sdk.py
@@ -93,9 +93,12 @@ def get_host_gpu() -> str:
         )
         return "dgpu"
 
-    # Check for iGPU (Orin integrated GPU)
+    # Orin (nvgpu) appears on both JP6.x (integrated GPU stack, driver ~540)
+    # and JP7.x (SBSA-compatible dGPU stack, driver >= 580). Use CUDA/driver
+    # version to distinguish: JP6.x / IGX OS 1.x ship CUDA 12 (driver < 580);
+    # JP7.x / IGX OS 2.x ship CUDA 13 (driver >= 580).
     if "Orin (nvgpu)" in gpu_name:
-        return "igpu"
+        return "igpu" if get_default_cuda_version() == "12" else "dgpu"
     return "dgpu"
 
 
@@ -148,9 +151,9 @@ def get_cuda_tag(
     - SDK < 3.6.1: Old format (dgpu/igpu)
     - SDK == 3.6.1: only cuda13-dgpu available
     - SDK >= 3.7.0: Full CUDA support
-      - cuda13: CUDA 13 (x86_64, Jetson Thor)
+      - cuda13: CUDA 13 (x86_64, Jetson AGX Orin w/ JP7.x, Jetson AGX Thor w/ JP7.x)
       - cuda12-dgpu: CUDA 12 dGPU (x86_64, IGX Orin dGPU, Clara AGX dGPU, GH200)
-      - cuda12-igpu: CUDA 12 iGPU (Jetson Orin, IGX Orin iGPU, Clara AGX iGPU)
+      - cuda12-igpu: CUDA 12 iGPU (Jetson AGX Orin w/ JP6.x, IGX Orin iGPU w/ IGX OS 1.x, Clara AGX iGPU)
 
     Args:
         cuda_version: CUDA major version (e.g., 12, 13). If None, uses platform default.

--- a/tests/unit/test_sdk_utils.py
+++ b/tests/unit/test_sdk_utils.py
@@ -61,10 +61,25 @@ def test_get_host_gpu_defaults_to_dgpu_without_driver(monkeypatch, capsys):
     assert "Defaulting build to target dGPU/CPU stack" in capsys.readouterr().err
 
 
-def test_get_host_gpu_detects_orin_igpu(monkeypatch):
+def test_get_host_gpu_orin_driver_disambiguation(monkeypatch):
     monkeypatch.setattr(sdk, "get_gpu_name", lambda: "Orin (nvgpu)")
 
+    monkeypatch.setattr(sdk, "get_default_cuda_version", lambda: "12")
     assert sdk.get_host_gpu() == "igpu"
+
+    sdk.get_host_gpu.cache_clear()
+    monkeypatch.setattr(sdk, "get_default_cuda_version", lambda: "13")
+    assert sdk.get_host_gpu() == "dgpu"
+
+    sdk.get_host_gpu.cache_clear()
+    monkeypatch.setattr(sdk, "get_default_cuda_version", lambda: None)
+    assert sdk.get_host_gpu() == "dgpu"
+
+
+def test_get_host_gpu_non_orin(monkeypatch):
+    monkeypatch.setattr(sdk, "get_gpu_name", lambda: "NVIDIA RTX 4090")
+
+    assert sdk.get_host_gpu() == "dgpu"
 
 
 def test_get_default_cuda_version_from_driver(monkeypatch):


### PR DESCRIPTION
## Summary
- Port the HoloHub CLI fix from nvidia-holoscan/holohub#1601 for Orin GPU_TYPE detection.
- Classify Orin (nvgpu) as igpu for CUDA 12 / JetPack 6.x and dgpu for CUDA 13 / JetPack 7.x.
- Add SDK utility tests for Orin CUDA-major disambiguation and non-Orin fallback behavior.

## Upstream CLI Audit
- HoloHub CLI commits after the last local sync through #1596: #1597 and #1601.
- #1597 package --cuda forwarding is already present in this repo.
- #1601 is ported in this PR.
- Other recent upstream commits were app/module/docs/website changes, not holoscan-cli changes.

## Validation
- python -m pytest -q tests/unit/test_sdk_utils.py tests/unit/test_package_cmd.py
- python -m pytest -q
- python -m ruff check src/holoscan_cli/utils/sdk.py tests/unit/test_sdk_utils.py

AI-assisted: Created with Codex/GPT at the user's request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced GPU type detection on Orin-based systems to accurately distinguish between integrated and discrete GPUs based on detected CUDA version.

* **Documentation**
  * Updated GPU identification and CUDA container tag mapping documentation for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->