### PR TITLE
Honor CTest script env override before container run

### DIFF
--- a/src/holoscan_cli/commands/test_cmd.py
+++ b/src/holoscan_cli/commands/test_cmd.py
@@ -82,15 +82,19 @@ def _ctest_script_arg(cli, args: argparse.Namespace, in_container: bool) -> str:
     host is recursing in via ``docker run ... bash -c "<ctest_cmd>"``), the
     host's ``HoloscanCLI.DEFAULT_CTEST_SCRIPT`` points at the host's
     ``site-packages`` and will not exist inside the container if the install
-    prefix differs. Defer the resolution to runtime by emitting a Python
-    one-liner the in-container shell evaluates; this honors any
-    ``HOLOSCAN_CLI_CTEST_SCRIPT`` value forwarded into the container and
-    falls back to the in-container package's bundled script. The host's
-    local path (``--local`` on the host, or the in-container ``--local``
-    recursion branch) keeps the direct host-resolved path.
+    prefix differs. A caller-provided ``--ctest-script`` or
+    ``HOLOSCAN_CLI_CTEST_SCRIPT`` override is already meaningful in the
+    source tree that will be mounted into the container, so render it as a
+    literal path on the host. Otherwise, defer the bundled-script resolution
+    to runtime by emitting a Python one-liner the in-container shell
+    evaluates. The host's local path (``--local`` on the host, or the
+    in-container ``--local`` recursion branch) keeps the direct host-resolved
+    path.
     """
     if args.ctest_script:
         return f"-S {args.ctest_script}"
+    if env_ctest_script := os.environ.get("HOLOSCAN_CLI_CTEST_SCRIPT"):
+        return f"-S {env_ctest_script}"
     if not in_container:
         return f"-S {cli.DEFAULT_CTEST_SCRIPT}"
     return (

--- a/tests/unit/test_container_recursion.py
+++ b/tests/unit/test_container_recursion.py
@@ -146,8 +146,18 @@ def test_ctest_script_arg_uses_user_override():
     assert _ctest_script_arg(cli, args, in_container=False) == "-S cmake/isaac_os.container.ctest"
 
 
+def test_ctest_script_arg_uses_env_override(monkeypatch):
+    monkeypatch.setenv("HOLOSCAN_CLI_CTEST_SCRIPT", "cmake/env.container.ctest")
+    cli = _bare_cli()
+    args = SimpleNamespace(ctest_script=None)
+
+    assert _ctest_script_arg(cli, args, in_container=True) == "-S cmake/env.container.ctest"
+    assert _ctest_script_arg(cli, args, in_container=False) == "-S cmake/env.container.ctest"
+
+
 def test_ctest_script_arg_local_uses_host_resolved_path(monkeypatch):
     cli = _bare_cli()
+    monkeypatch.delenv("HOLOSCAN_CLI_CTEST_SCRIPT", raising=False)
     monkeypatch.setattr(
         project_cli.HoloscanCLI, "DEFAULT_CTEST_SCRIPT", "/host/path/container.ctest"
     )
@@ -156,7 +166,8 @@ def test_ctest_script_arg_local_uses_host_resolved_path(monkeypatch):
     assert _ctest_script_arg(cli, args, in_container=False) == "-S /host/path/container.ctest"
 
 
-def test_ctest_script_arg_container_defers_resolution_to_runtime():
+def test_ctest_script_arg_container_defers_resolution_to_runtime(monkeypatch):
+    monkeypatch.delenv("HOLOSCAN_CLI_CTEST_SCRIPT", raising=False)
     cli = _bare_cli()
     args = SimpleNamespace(ctest_script=None)
 

--- a/tests/unit/test_lifecycle_commands.py
+++ b/tests/unit/test_lifecycle_commands.py
@@ -507,6 +507,32 @@ def test_handle_test_container_adds_coverage_build_args_and_ctest_options(tmp_pa
     assert "-DCASE=smoke" in ctest_command
 
 
+def test_handle_test_container_uses_env_ctest_script_literal(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOLOSCAN_CLI_CTEST_SCRIPT", "utilities/testing/holohub.container.ctest")
+    cli = RecordingCLI(tmp_path)
+    args = _container_args(
+        coverage=False,
+        clear_cache=False,
+        no_xvfb=True,
+        site_name=None,
+        cdash_url=None,
+        platform_name=None,
+        cmake_options=None,
+        ctest_options=None,
+        ctest_script=None,
+        build_name_suffix=None,
+        language=None,
+        no_docker_build=True,
+    )
+
+    test_cmd.handle_test(cli, args)
+
+    assert cli.container.build_calls == []
+    ctest_command = cli.container.run_calls[0]["extra_args"][1]
+    assert "-S utilities/testing/holohub.container.ctest" in ctest_command
+    assert "from holoscan_cli.cli import HoloscanCLI" not in ctest_command
+
+
 def test_handle_test_local_runs_ctest_in_repo_with_environment(tmp_path, monkeypatch):
     cli = RecordingCLI(tmp_path)
     calls = []


### PR DESCRIPTION
## Summary
- render HOLOSCAN_CLI_CTEST_SCRIPT as a literal ctest -S argument before entering app containers
- keep the existing in-container Python fallback only when no explicit CLI/env override is configured
- add helper-level and command-level regression tests for the env override path

## Tests
- PYTHONPATH=src PYTHONDONTWRITEBYTECODE=1 python -m pytest -q -o addopts='' -p no:cacheprovider tests/unit/test_container_recursion.py tests/unit/test_lifecycle_commands.py
- PYTHONPATH=src PYTHONDONTWRITEBYTECODE=1 python -m pytest -q -o addopts='' -p no:cacheprovider tests/unit
- PYTHONPATH=src RUFF_CACHE_DIR=/tmp/holoscan-cli-ruff-cache python -m ruff check src/holoscan_cli/commands/test_cmd.py tests/unit/test_container_recursion.py tests/unit/test_lifecycle_commands.py
- python -m black --check src/holoscan_cli/commands/test_cmd.py tests/unit/test_container_recursion.py tests/unit/test_lifecycle_commands.py
- python -m isort --check-only src/holoscan_cli/commands/test_cmd.py tests/unit/test_container_recursion.py tests/unit/test_lifecycle_commands.py
- PRE_COMMIT_HOME=/tmp/holoscan-cli-pre-commit-cache python -m pre_commit run --show-diff-on-failure --files src/holoscan_cli/commands/test_cmd.py tests/unit/test_container_recursion.py tests/unit/test_lifecycle_commands.py

AI-assisted: Created with Codex/GPT at the user's request.