### PR TITLE
Fix README links for PyPI rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,12 @@ first.
 
 ## Contributing
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for details.
-[`.github/CI.md`](./.github/CI.md) covers the CI/release pipelines that back
-the workflow badges at the top of this page.
+See
+[CONTRIBUTING.md](https://github.com/nvidia-holoscan/holoscan-cli/blob/main/CONTRIBUTING.md)
+for details.
+[`.github/CI.md`](https://github.com/nvidia-holoscan/holoscan-cli/blob/main/.github/CI.md)
+covers the CI/release pipelines that back the workflow badges at the top of
+this page.
 
 ## Deprecations
 

--- a/tests/unit/test_package_data.py
+++ b/tests/unit/test_package_data.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import importlib.metadata
 import importlib.resources
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -74,12 +75,19 @@ REQUIRED_SETUP_SCRIPTS = {
 
 
 PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
+README = Path(__file__).resolve().parents[2] / "README.md"
 
 
 def _pyproject() -> dict:
     if not PYPROJECT.exists():
         pytest.skip(f"pyproject.toml not found at {PYPROJECT}")
     return tomllib.loads(PYPROJECT.read_text())
+
+
+def _readme() -> str:
+    if not README.exists():
+        pytest.skip(f"README.md not found at {README}")
+    return README.read_text(encoding="utf-8")
 
 
 # ---- bundled package data ---------------------------------------------------
@@ -156,6 +164,24 @@ def test_bundled_template_script_uses_bundled_requirements(tmp_path):
         "-r",
         str(requirements),
     ]
+
+
+def test_readme_links_are_valid_for_pypi_rendering():
+    """PyPI renders README.md as the long description, outside the GitHub repo.
+
+    Repo-relative links such as ``./CONTRIBUTING.md`` become broken PyPI URLs, so
+    docs shipped in package metadata should use absolute URLs or page anchors.
+    """
+    relative_links = []
+    for match in re.finditer(r"(?<!!)\[[^\]]+\]\(([^)]+)\)", _readme()):
+        target = match.group(1).strip()
+        if target.startswith(("#", "http://", "https://", "mailto:")):
+            continue
+        if "://" in target:
+            continue
+        relative_links.append(target)
+
+    assert not relative_links, f"README has PyPI-broken relative links: {relative_links}"
 
 
 # ---- pyproject.toml entry-point declarations --------------------------------


### PR DESCRIPTION
## Summary
- replace repo-relative README links with absolute GitHub URLs so PyPI long descriptions do not render broken links
- add a package metadata test that rejects relative README links in future releases

## Testing
- `python -m pytest -q -o addopts='' tests/unit/test_package_data.py`
- `python -m ruff check tests/unit/test_package_data.py`
- `python -m black --check tests/unit/test_package_data.py`
- `python -m pytest -q -o addopts='' tests/unit`
- `git diff --check`

AI-assisted: Created with Codex/GPT at the user's request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub links in the Contributing section to use main-branch absolute references instead of relative paths, improving documentation stability across distribution formats.

* **Tests**
  * Added validation to ensure all links in the packaged README are compatible with PyPI rendering and contain no invalid relative link references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->