### PR TITLE
[codex] Activate module dev hooks for local runs

### DIFF
--- a/src/holoscan_cli/commands/run.py
+++ b/src/holoscan_cli/commands/run.py
@@ -34,6 +34,30 @@ from holoscan_cli.utils.holohub import (
 from holoscan_cli.utils.io import fatal, format_cmd, run_command
 
 
+def _staged_module_dev_hook_names(build_dir: Path) -> list[str]:
+    """Return generated Holoscan Module dev hook module names."""
+    return sorted(helper.stem for helper in build_dir.glob("holoscan_*_dev.py"))
+
+
+def _with_staged_module_dev_hooks(cmd: list[str], hook_names: list[str]) -> list[str]:
+    """Import staged module dev hooks before running a Python script."""
+    if not hook_names or len(cmd) < 2:
+        return cmd
+    if not Path(cmd[0]).name.startswith("python") or cmd[1].startswith("-"):
+        return cmd
+
+    hook_loader = (
+        "import importlib, runpy, sys;"
+        "from pathlib import Path;"
+        f"[importlib.import_module(name) for name in {hook_names!r}];"
+        "script = sys.argv[1];"
+        "sys.argv = sys.argv[1:];"
+        "sys.path[0] = str(Path(script).resolve().parent);"
+        "runpy.run_path(script, run_name='__main__')"
+    )
+    return [cmd[0], "-c", hook_loader, *cmd[1:]]
+
+
 def register_run_parser(
     cli, subparsers, *, container_build, container_run
 ) -> argparse.ArgumentParser:
@@ -180,9 +204,19 @@ def handle_run(cli, args: argparse.Namespace) -> None:
 
         # Set up run environment variables
         run_env = os.environ.copy()
-        run_env["PYTHONPATH"] = (
-            f"{run_env.get('PYTHONPATH', '')}:{cli.DEFAULT_SDK_DIR}/python/lib:{build_dir}/python/lib:{cli.HOLOHUB_ROOT}"
+        module_dev_hook_names = _staged_module_dev_hook_names(build_dir)
+        pythonpath_entries = [str(build_dir)] if module_dev_hook_names else []
+        pythonpath_entries.extend(
+            entry
+            for entry in (
+                run_env.get("PYTHONPATH", ""),
+                f"{cli.DEFAULT_SDK_DIR}/python/lib",
+                str(build_dir / "python" / "lib"),
+                str(cli.HOLOHUB_ROOT),
+            )
+            if entry
         )
+        run_env["PYTHONPATH"] = ":".join(pythonpath_entries)
         run_env["HOLOSCAN_CLI_DATA_PATH"] = str(cli.DEFAULT_DATA_DIR)
         run_env["HOLOSCAN_INPUT_PATH"] = run_env.get(
             "HOLOSCAN_INPUT_PATH", str(cli.DEFAULT_DATA_DIR)
@@ -261,6 +295,7 @@ def handle_run(cli, args: argparse.Namespace) -> None:
             cmd = f"{nsys_cmd} profile --trace=cuda,vulkan,nvtx,osrt {cmd}"
 
         cmd_to_run = cmd if isinstance(cmd, list) else shlex.split(cmd)
+        cmd_to_run = _with_staged_module_dev_hooks(cmd_to_run, module_dev_hook_names)
         run_command(cmd_to_run, env=run_env, dry_run=args.dryrun)
     else:
         container = cli.make_project_container(

--- a/tests/unit/test_lifecycle_commands.py
+++ b/tests/unit/test_lifecycle_commands.py
@@ -382,6 +382,53 @@ def test_handle_run_local_dryrun_builds_mapping_and_executes_command(tmp_path, m
     assert kwargs["dry_run"] is True
 
 
+def test_handle_run_local_activates_staged_module_dev_hook(tmp_path, monkeypatch):
+    module_dir = tmp_path / "repo" / "modules" / "holoscan-smoke"
+    module_dir.mkdir(parents=True)
+    project = {
+        "project_name": "holoscan-smoke",
+        "project_type": "module",
+        "source_folder": module_dir,
+        "metadata": {
+            "language": "python",
+            "run": {"command": "python3 app.py", "workdir": ""},
+        },
+    }
+    cli = RecordingCLI(tmp_path, project)
+    build_dir = tmp_path / "build" / "holoscan-smoke"
+    build_dir.mkdir(parents=True)
+    (build_dir / "holoscan_smoke_dev.py").write_text("# helper\n", encoding="utf-8")
+    (build_dir / "holoscan-smoke-dev.pth").write_text(
+        "import holoscan_smoke_dev\n", encoding="utf-8"
+    )
+    calls = []
+    monkeypatch.setattr(
+        run_cmd,
+        "build_project_locally",
+        lambda *args, **kwargs: (build_dir, cli.project_data),
+    )
+    monkeypatch.setattr(run_cmd, "run_command", lambda cmd, **kwargs: calls.append((cmd, kwargs)))
+
+    run_cmd.handle_run(
+        cli,
+        _project_args(
+            project="holoscan-smoke",
+            local=True,
+            language="python",
+            dryrun=False,
+        ),
+    )
+
+    command, kwargs = calls[0]
+    assert command[0:2] == ["python3", "-c"]
+    assert "importlib.import_module(name)" in command[2]
+    assert "holoscan_smoke_dev" in command[2]
+    assert "sys.path[0]" in command[2]
+    assert command[3:] == ["app.py"]
+    assert not (build_dir / ".holoscan_cli_runtime").exists()
+    assert kwargs["env"]["PYTHONPATH"].split(":")[0] == str(build_dir)
+
+
 def test_handle_run_container_branch_passes_recursive_local_command(tmp_path, monkeypatch):
     cli = RecordingCLI(tmp_path)
     captured = {}


### PR DESCRIPTION
## Summary
- activate staged Holoscan Module dev hooks during local `run` commands
- add a regression test for module build directories that stage a dev hook

## Tests
- `PYTHONDONTWRITEBYTECODE=1 python -m pytest -q -o addopts='' -o cache_dir=/tmp/holoscan-cli-pytest-cache tests/unit/test_lifecycle_commands.py`
- `RUFF_CACHE_DIR=/tmp/holoscan-cli-ruff-cache PYTHONDONTWRITEBYTECODE=1 python -m ruff check src/holoscan_cli/commands/run.py tests/unit/test_lifecycle_commands.py`