### PR TITLE
fix: destructive-boundary guard for clear-cache

### DIFF
--- a/src/holoscan_cli/commands/clear_cache.py
+++ b/src/holoscan_cli/commands/clear_cache.py
@@ -20,47 +20,34 @@ import shutil
 from pathlib import Path
 
 from holoscan_cli.commands.registry import help_for
-from holoscan_cli.utils.io import Color
-
-
-def _resolve(path) -> Path:
-    """Canonicalize a path: expand ``~``, follow symlinks, make absolute."""
-    return Path(path).expanduser().resolve()
+from holoscan_cli.utils.io import Color, resolve
 
 
 def _is_safe_to_remove(path: Path, cli) -> bool:
-    """Return ``True`` only when ``path`` is a real cache directory we may delete.
+    """Return ``True`` only when ``path`` is a cache directory we may delete.
 
-    ``clear-cache`` feeds :func:`shutil.rmtree` with directories derived from
-    ``DEFAULT_BUILD_PARENT_DIR`` / ``DEFAULT_DATA_DIR`` and repo-root globs, all
-    of which are user-overridable via environment variables. A hostile or
-    fat-fingered value (e.g. ``HOLOSCAN_CLI_BUILD_PARENT_DIR=/``) must never let
-    the command wipe the filesystem root, the user's home, or the repository
-    itself. This guard canonicalizes the candidate and enforces two rules:
-
-    1. It is not a critical anchor (``/``, ``$HOME``, the repo root) and is not
-       an ancestor of one — deleting such a path would take the anchor with it.
-    2. It lives at or under an approved cache root (the repo tree, the build
-       parent dir, or the data dir).
+    The candidate dirs come from env-overridable roots (e.g.
+    ``HOLOSCAN_CLI_BUILD_PARENT_DIR=/``), so a bad value must never let
+    :func:`shutil.rmtree` wipe an anchor (``/``, ``$HOME``, the repo root) or
+    an ancestor of one; the path must also live under an approved cache root.
     """
-    candidate = _resolve(path)
+    candidate = resolve(path)
 
-    anchors = {_resolve("/"), _resolve(cli.HOLOHUB_ROOT)}
+    anchors = {resolve("/"), resolve(cli.HOLOHUB_ROOT)}
     try:
-        anchors.add(_resolve(Path.home()))
+        anchors.add(resolve(Path.home()))
     except RuntimeError:
         pass  # home directory unresolvable; the remaining anchors still apply
     if candidate in anchors:
         return False
-    # Refuse ancestors of any anchor (e.g. a parent of the repo root or home).
     for anchor in anchors:
         if anchor.is_relative_to(candidate):
             return False
 
     approved_roots = [
-        _resolve(cli.HOLOHUB_ROOT),
-        _resolve(cli.DEFAULT_BUILD_PARENT_DIR),
-        _resolve(cli.DEFAULT_DATA_DIR),
+        resolve(cli.HOLOHUB_ROOT),
+        resolve(cli.DEFAULT_BUILD_PARENT_DIR),
+        resolve(cli.DEFAULT_DATA_DIR),
     ]
     return any(candidate.is_relative_to(root) for root in approved_roots)
 

--- a/src/holoscan_cli/commands/clear_cache.py
+++ b/src/holoscan_cli/commands/clear_cache.py
@@ -45,7 +45,11 @@ def _is_safe_to_remove(path: Path, cli) -> bool:
     """
     candidate = _resolve(path)
 
-    anchors = {_resolve("/"), _resolve(Path.home()), _resolve(cli.HOLOHUB_ROOT)}
+    anchors = {_resolve("/"), _resolve(cli.HOLOHUB_ROOT)}
+    try:
+        anchors.add(_resolve(Path.home()))
+    except RuntimeError:
+        pass  # home directory unresolvable; the remaining anchors still apply
     if candidate in anchors:
         return False
     # Refuse ancestors of any anchor (e.g. a parent of the repo root or home).

--- a/src/holoscan_cli/commands/clear_cache.py
+++ b/src/holoscan_cli/commands/clear_cache.py
@@ -17,9 +17,48 @@
 
 import argparse
 import shutil
+from pathlib import Path
 
 from holoscan_cli.commands.registry import help_for
 from holoscan_cli.utils.io import Color
+
+
+def _resolve(path) -> Path:
+    """Canonicalize a path: expand ``~``, follow symlinks, make absolute."""
+    return Path(path).expanduser().resolve()
+
+
+def _is_safe_to_remove(path: Path, cli) -> bool:
+    """Return ``True`` only when ``path`` is a real cache directory we may delete.
+
+    ``clear-cache`` feeds :func:`shutil.rmtree` with directories derived from
+    ``DEFAULT_BUILD_PARENT_DIR`` / ``DEFAULT_DATA_DIR`` and repo-root globs, all
+    of which are user-overridable via environment variables. A hostile or
+    fat-fingered value (e.g. ``HOLOSCAN_CLI_BUILD_PARENT_DIR=/``) must never let
+    the command wipe the filesystem root, the user's home, or the repository
+    itself. This guard canonicalizes the candidate and enforces two rules:
+
+    1. It is not a critical anchor (``/``, ``$HOME``, the repo root) and is not
+       an ancestor of one — deleting such a path would take the anchor with it.
+    2. It lives at or under an approved cache root (the repo tree, the build
+       parent dir, or the data dir).
+    """
+    candidate = _resolve(path)
+
+    anchors = {_resolve("/"), _resolve(Path.home()), _resolve(cli.HOLOHUB_ROOT)}
+    if candidate in anchors:
+        return False
+    # Refuse ancestors of any anchor (e.g. a parent of the repo root or home).
+    for anchor in anchors:
+        if anchor.is_relative_to(candidate):
+            return False
+
+    approved_roots = [
+        _resolve(cli.HOLOHUB_ROOT),
+        _resolve(cli.DEFAULT_BUILD_PARENT_DIR),
+        _resolve(cli.DEFAULT_DATA_DIR),
+    ]
+    return any(candidate.is_relative_to(root) for root in approved_roots)
 
 
 def register_clear_cache_parser(cli, subparsers) -> argparse.ArgumentParser:
@@ -67,9 +106,13 @@ def handle_clear_cache(cli, args: argparse.Namespace) -> None:
         cache_dirs.extend(cli.collect_cache_dirs(["install", "install-*"]))
 
     for path in set(cache_dirs):
-        if path.exists() and path.is_dir():
-            if args.dryrun:
-                print(f"  {Color.yellow('Would remove:')} {path}")
-            else:
-                print(f"  {Color.red('Removing:')} {path}")
-                shutil.rmtree(path)
+        if not (path.exists() and path.is_dir()):
+            continue
+        if not _is_safe_to_remove(path, cli):
+            print(f"  {Color.red('Refusing to remove:')} {path} (outside approved cache roots)")
+            continue
+        if args.dryrun:
+            print(f"  {Color.yellow('Would remove:')} {path}")
+        else:
+            print(f"  {Color.red('Removing:')} {path}")
+            shutil.rmtree(path)

--- a/src/holoscan_cli/commands/test_cmd.py
+++ b/src/holoscan_cli/commands/test_cmd.py
@@ -110,11 +110,9 @@ def handle_test(cli, args: argparse.Namespace) -> None:
 
         from holoscan_cli.commands.clear_cache import handle_clear_cache
 
-        # `test --clear-cache` clears build/install artifacts only — never the
-        # downloaded data cache. Forwarding the test namespace directly would
-        # leave build/data/install unset, which clear-cache treats as "clear
-        # everything" (including data), regressing the historical HoloHub
-        # behavior. Select the families explicitly instead.
+        # Clear build/install artifacts only — forwarding the test namespace
+        # (no build/data/install flags) would mean "clear everything",
+        # including the downloaded data cache.
         handle_clear_cache(
             cli,
             Namespace(dryrun=args.dryrun, build=True, data=False, install=True),

--- a/src/holoscan_cli/commands/test_cmd.py
+++ b/src/holoscan_cli/commands/test_cmd.py
@@ -106,9 +106,19 @@ def handle_test(cli, args: argparse.Namespace) -> None:
         project_name=args.project, language=args.language if hasattr(args, "language") else None
     )
     if args.clear_cache:
+        from argparse import Namespace
+
         from holoscan_cli.commands.clear_cache import handle_clear_cache
 
-        handle_clear_cache(cli, args)
+        # `test --clear-cache` clears build/install artifacts only — never the
+        # downloaded data cache. Forwarding the test namespace directly would
+        # leave build/data/install unset, which clear-cache treats as "clear
+        # everything" (including data), regressing the historical HoloHub
+        # behavior. Select the families explicitly instead.
+        handle_clear_cache(
+            cli,
+            Namespace(dryrun=args.dryrun, build=True, data=False, install=True),
+        )
 
     container.dryrun = args.dryrun
     container.verbose = args.verbose

--- a/src/holoscan_cli/utils/io.py
+++ b/src/holoscan_cli/utils/io.py
@@ -14,7 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Terminal output (Color + info/warn/fatal) and subprocess execution."""
+"""Terminal output (Color + info/warn/fatal), path canonicalization, and
+subprocess execution."""
 
 import os
 import shutil
@@ -22,7 +23,14 @@ import subprocess
 import sys
 import traceback
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import List, Optional, Tuple, Union
+
+
+def resolve(path) -> Path:
+    """Canonicalize a path: expand ``~``, follow symlinks, make absolute."""
+    return Path(path).expanduser().resolve()
+
 
 # ---- terminal color formatting -----------------------------------------------
 

--- a/tests/unit/test_cli_behaviors.py
+++ b/tests/unit/test_cli_behaviors.py
@@ -247,3 +247,55 @@ def test_clear_cache_dryrun_reports_would_remove_paths(tmp_path, monkeypatch, ca
     out = capsys.readouterr().out
     assert "Would remove:" in out
     assert str(build_parent) in out
+
+
+@pytest.mark.parametrize("target", ["fs_root", "home", "repo_root", "ancestor"])
+def test_clear_cache_refuses_dangerous_roots(tmp_path, monkeypatch, capsys, target):
+    """A hostile/fat-fingered cache root (e.g. ``HOLOSCAN_CLI_BUILD_PARENT_DIR=/``)
+    must never let clear-cache rmtree the filesystem root, ``$HOME``, the repo
+    root, or an ancestor of the repo root."""
+    repo_root = tmp_path / "workspace" / "repo"
+    repo_root.mkdir(parents=True)
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
+    dangerous = {
+        "fs_root": Path("/").resolve(),
+        "home": home,
+        "repo_root": repo_root,
+        "ancestor": repo_root.parent,
+    }[target]
+
+    monkeypatch.setattr(project_cli.HoloscanCLI, "HOLOHUB_ROOT", repo_root)
+    cli = object.__new__(project_cli.HoloscanCLI)
+    cli.DEFAULT_BUILD_PARENT_DIR = dangerous
+    cli.DEFAULT_DATA_DIR = tmp_path / "data"
+
+    with patch.object(clear_cache_cmd.shutil, "rmtree") as rmtree:
+        clear_cache_cmd.handle_clear_cache(
+            cli, Namespace(dryrun=False, build=True, data=False, install=False)
+        )
+
+    rmtree.assert_not_called()
+    assert "Refusing to remove:" in capsys.readouterr().out
+    assert dangerous.is_dir()
+
+
+def test_test_clear_cache_selects_build_install_only(monkeypatch):
+    """`test --clear-cache` clears build/install artifacts but never data."""
+    from holoscan_cli.commands import test_cmd
+
+    captured = {}
+    monkeypatch.setattr(test_cmd, "check_skip_builds", lambda args: (True, True))
+    monkeypatch.setattr(
+        "holoscan_cli.commands.clear_cache.handle_clear_cache",
+        lambda cli, args: captured.update(vars(args)),
+    )
+    cli = object.__new__(project_cli.HoloscanCLI)
+    monkeypatch.setattr(cli, "make_project_container", lambda **kw: Namespace(dryrun=False))
+
+    args = Namespace(project=None, language=None, clear_cache=True, dryrun=False, local=True)
+    with pytest.raises(Exception):  # downstream local run needs more of the namespace
+        test_cmd.handle_test(cli, args)
+
+    assert (captured["build"], captured["install"], captured["data"]) == (True, True, False)

--- a/tests/unit/test_cli_behaviors.py
+++ b/tests/unit/test_cli_behaviors.py
@@ -249,41 +249,32 @@ def test_clear_cache_dryrun_reports_would_remove_paths(tmp_path, monkeypatch, ca
     assert str(build_parent) in out
 
 
-@pytest.mark.parametrize("target", ["fs_root", "home", "repo_root", "ancestor"])
-def test_clear_cache_refuses_dangerous_roots(tmp_path, monkeypatch, capsys, target):
-    """A hostile/fat-fingered cache root (e.g. ``HOLOSCAN_CLI_BUILD_PARENT_DIR=/``)
-    must never let clear-cache rmtree the filesystem root, ``$HOME``, the repo
-    root, or an ancestor of the repo root."""
+def test_clear_cache_refuses_dangerous_roots(tmp_path, monkeypatch, capsys):
+    """A bad cache root (e.g. ``HOLOSCAN_CLI_BUILD_PARENT_DIR=/``) must never
+    let clear-cache rmtree an anchor (``/``, ``$HOME``, repo root) or an
+    ancestor of one."""
     repo_root = tmp_path / "workspace" / "repo"
     repo_root.mkdir(parents=True)
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
-    dangerous = {
-        "fs_root": Path("/").resolve(),
-        "home": home,
-        "repo_root": repo_root,
-        "ancestor": repo_root.parent,
-    }[target]
-
     monkeypatch.setattr(project_cli.HoloscanCLI, "HOLOHUB_ROOT", repo_root)
     cli = object.__new__(project_cli.HoloscanCLI)
-    cli.DEFAULT_BUILD_PARENT_DIR = dangerous
     cli.DEFAULT_DATA_DIR = tmp_path / "data"
 
-    with patch.object(clear_cache_cmd.shutil, "rmtree") as rmtree:
-        clear_cache_cmd.handle_clear_cache(
-            cli, Namespace(dryrun=False, build=True, data=False, install=False)
-        )
-
-    rmtree.assert_not_called()
+    for dangerous in (Path("/").resolve(), home, repo_root, repo_root.parent):
+        cli.DEFAULT_BUILD_PARENT_DIR = dangerous
+        with patch.object(clear_cache_cmd.shutil, "rmtree") as rmtree:
+            clear_cache_cmd.handle_clear_cache(
+                cli, Namespace(dryrun=False, build=True, data=False, install=False)
+            )
+        rmtree.assert_not_called()
+        assert dangerous.is_dir()
     assert "Refusing to remove:" in capsys.readouterr().out
-    assert dangerous.is_dir()
 
 
 def test_clear_cache_survives_unresolvable_home(tmp_path, monkeypatch):
-    """An unresolvable home directory (``Path.home()`` raising ``RuntimeError``)
-    must not abort clear-cache; the remaining anchors still guard removals."""
+    """``Path.home()`` raising ``RuntimeError`` must not abort clear-cache."""
 
     def raise_home():
         raise RuntimeError("Could not determine home directory.")
@@ -312,16 +303,18 @@ def test_test_clear_cache_selects_build_install_only(monkeypatch):
     from holoscan_cli.commands import test_cmd
 
     captured = {}
+
+    def fake_clear_cache(cli, args):
+        captured.update(vars(args))
+        raise SystemExit  # stop before the rest of handle_test runs
+
     monkeypatch.setattr(test_cmd, "check_skip_builds", lambda args: (True, True))
-    monkeypatch.setattr(
-        "holoscan_cli.commands.clear_cache.handle_clear_cache",
-        lambda cli, args: captured.update(vars(args)),
-    )
+    monkeypatch.setattr("holoscan_cli.commands.clear_cache.handle_clear_cache", fake_clear_cache)
     cli = object.__new__(project_cli.HoloscanCLI)
     monkeypatch.setattr(cli, "make_project_container", lambda **kw: Namespace(dryrun=False))
 
     args = Namespace(project=None, language=None, clear_cache=True, dryrun=False, local=True)
-    with pytest.raises(Exception):  # downstream local run needs more of the namespace
+    with pytest.raises(SystemExit):
         test_cmd.handle_test(cli, args)
 
     assert (captured["build"], captured["install"], captured["data"]) == (True, True, False)

--- a/tests/unit/test_cli_behaviors.py
+++ b/tests/unit/test_cli_behaviors.py
@@ -281,6 +281,32 @@ def test_clear_cache_refuses_dangerous_roots(tmp_path, monkeypatch, capsys, targ
     assert dangerous.is_dir()
 
 
+def test_clear_cache_survives_unresolvable_home(tmp_path, monkeypatch):
+    """An unresolvable home directory (``Path.home()`` raising ``RuntimeError``)
+    must not abort clear-cache; the remaining anchors still guard removals."""
+
+    def raise_home():
+        raise RuntimeError("Could not determine home directory.")
+
+    monkeypatch.setattr(Path, "home", staticmethod(raise_home))
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    build_parent = tmp_path / "build"
+    build_parent.mkdir()
+
+    monkeypatch.setattr(project_cli.HoloscanCLI, "HOLOHUB_ROOT", repo_root)
+    cli = object.__new__(project_cli.HoloscanCLI)
+    cli.DEFAULT_BUILD_PARENT_DIR = build_parent
+    cli.DEFAULT_DATA_DIR = tmp_path / "data"
+
+    clear_cache_cmd.handle_clear_cache(
+        cli, Namespace(dryrun=False, build=True, data=False, install=False)
+    )
+
+    assert not build_parent.exists()
+    assert repo_root.is_dir()
+
+
 def test_test_clear_cache_selects_build_install_only(monkeypatch):
     """`test --clear-cache` clears build/install artifacts but never data."""
     from holoscan_cli.commands import test_cmd


### PR DESCRIPTION
## Problem

The cache roots are user-overridable (`HOLOSCAN_CLI_BUILD_PARENT_DIR` / `HOLOSCAN_CLI_DATA_DIR`) and `clear-cache` passed them straight to `shutil.rmtree()`:

```
HOLOSCAN_CLI_BUILD_PARENT_DIR=/ ./holohub clear-cache --build --dryrun
  Would remove: /
```

Separately, `test --clear-cache` forwarded the raw test namespace, which clear-cache treats as "clear everything" — deleting the downloaded data cache instead of only build/install artifacts.

## Fix

- `clear-cache` canonicalizes each candidate (new `holoscan_cli.utils.io.resolve()`) and refuses to remove `/`, `$HOME`, the repo root, an ancestor of any of these, or anything outside the configured cache roots. Refused paths print `Refusing to remove: <path>` and are skipped. This is a backstop against the worst targets, not full validation of arbitrary overrides.
- `test --clear-cache` now selects build/install explicitly; data is preserved.
- Unit tests: refused anchors, unresolvable `$HOME` tolerated, and the build/install-only selection.

## Testing

`pytest tests/unit` passes; CI green on Python 3.10–3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
