### PR TITLE
fix: resolve in-container ctest script from env before importing the CLI

### DIFF
--- a/src/holoscan_cli/commands/test_cmd.py
+++ b/src/holoscan_cli/commands/test_cmd.py
@@ -82,10 +82,10 @@ def _ctest_script_arg(cli, args: argparse.Namespace, in_container: bool) -> str:
     host is recursing in via ``docker run ... bash -c "<ctest_cmd>"``), the
     host's ``HoloscanCLI.DEFAULT_CTEST_SCRIPT`` points at the host's
     ``site-packages`` and will not exist inside the container if the install
-    prefix differs. Defer the resolution to runtime by emitting a Python
-    one-liner the in-container shell evaluates; this honors any
-    ``HOLOSCAN_CLI_CTEST_SCRIPT`` value forwarded into the container and
-    falls back to the in-container package's bundled script. The host's
+    prefix differs. Defer the resolution to runtime: use the
+    ``HOLOSCAN_CLI_CTEST_SCRIPT`` value forwarded into the container when
+    set (no in-container CLI install required), and only fall back to
+    importing the in-container package for its bundled script. The host's
     local path (``--local`` on the host, or the in-container ``--local``
     recursion branch) keeps the direct host-resolved path.
     """
@@ -94,8 +94,9 @@ def _ctest_script_arg(cli, args: argparse.Namespace, in_container: bool) -> str:
     if not in_container:
         return f"-S {cli.DEFAULT_CTEST_SCRIPT}"
     return (
-        "-S \"$(python3 -c 'from holoscan_cli.cli import HoloscanCLI; "
-        "print(HoloscanCLI.DEFAULT_CTEST_SCRIPT)')\""
+        '-S "${HOLOSCAN_CLI_CTEST_SCRIPT:-'
+        "$(python3 -c 'from holoscan_cli.cli import HoloscanCLI; "
+        "print(HoloscanCLI.DEFAULT_CTEST_SCRIPT)')}\""
     )
 
 

--- a/tests/unit/test_container_recursion.py
+++ b/tests/unit/test_container_recursion.py
@@ -162,7 +162,9 @@ def test_ctest_script_arg_container_defers_resolution_to_runtime():
 
     rendered = _ctest_script_arg(cli, args, in_container=True)
 
-    assert rendered.startswith('-S "$(python3 -c '), rendered
+    # Env-first so a forwarded HOLOSCAN_CLI_CTEST_SCRIPT works without any
+    # in-container CLI install; python import is only the fallback.
+    assert rendered.startswith('-S "${HOLOSCAN_CLI_CTEST_SCRIPT:-'), rendered
     assert "from holoscan_cli.cli import HoloscanCLI" in rendered
     assert "HoloscanCLI.DEFAULT_CTEST_SCRIPT" in rendered
     assert "/host/" not in rendered, "must not bake host paths into the in-container command"


### PR DESCRIPTION
The in-container `ctest -S` argument imported `holoscan_cli` just to locate the ctest script, so `test` failed in images without an importable CLI even though `HOLOSCAN_CLI_CTEST_SCRIPT` is already forwarded into the container. Use the forwarded env value first and keep the import only as the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved containerized test execution by resolving the CTest script path at runtime.
  * Respects the configured `HOLOSCAN_CLI_CTEST_SCRIPT` value, with a fallback when it is not set.

* **Tests**
  * Updated coverage to verify environment-based CTest script resolution in containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->