### PR TITLE
fix: parse HOLOSCAN_CLI_BUILD_LOCAL as a boolean, not Python truthiness

### DIFF
--- a/src/holoscan_cli/commands/build.py
+++ b/src/holoscan_cli/commands/build.py
@@ -44,7 +44,7 @@ from holoscan_cli.utils.holohub import (
     determine_project_prefix,
     get_buildtype_str,
     get_sccache_dir,
-    is_local_build_requested,
+    is_env_request_local_build,
     update_env,
 )
 from holoscan_cli.utils.io import fatal, info, run_command, warn
@@ -160,7 +160,7 @@ def handle_build(cli, args: argparse.Namespace) -> None:
     update_env(build_mode_env, mode_config.get("build", {}).get("env", {}))
 
     # Check if local mode is requested
-    is_local_mode = is_local_build_requested(args.local, build_mode_env)
+    is_local_mode = args.local or is_env_request_local_build(build_mode_env)
 
     if is_local_mode:
         build_project_locally(

--- a/src/holoscan_cli/commands/build.py
+++ b/src/holoscan_cli/commands/build.py
@@ -44,6 +44,7 @@ from holoscan_cli.utils.holohub import (
     determine_project_prefix,
     get_buildtype_str,
     get_sccache_dir,
+    is_local_build_requested,
     update_env,
 )
 from holoscan_cli.utils.io import fatal, info, run_command, warn
@@ -159,11 +160,7 @@ def handle_build(cli, args: argparse.Namespace) -> None:
     update_env(build_mode_env, mode_config.get("build", {}).get("env", {}))
 
     # Check if local mode is requested
-    is_local_mode = (
-        args.local
-        or os.environ.get("HOLOSCAN_CLI_BUILD_LOCAL")
-        or build_mode_env.get("HOLOSCAN_CLI_BUILD_LOCAL")
-    )
+    is_local_mode = is_local_build_requested(args.local, build_mode_env)
 
     if is_local_mode:
         build_project_locally(

--- a/src/holoscan_cli/commands/install.py
+++ b/src/holoscan_cli/commands/install.py
@@ -23,7 +23,12 @@ from pathlib import Path
 from holoscan_cli.commands.build import build_project_locally
 from holoscan_cli.commands.registry import help_for
 from holoscan_cli.utils.docker import get_entrypoint_command_args
-from holoscan_cli.utils.holohub import build_holohub_path_mapping, check_skip_builds, update_env
+from holoscan_cli.utils.holohub import (
+    build_holohub_path_mapping,
+    check_skip_builds,
+    is_local_build_requested,
+    update_env,
+)
 from holoscan_cli.utils.io import Color, fatal, run_command
 
 
@@ -134,11 +139,7 @@ def handle_install(cli, args: argparse.Namespace) -> None:
     update_env(build_mode_env, mode_config.get("build", {}).get("env", {}))
 
     # Check if local mode is requested
-    is_local_mode = (
-        args.local
-        or os.environ.get("HOLOSCAN_CLI_BUILD_LOCAL")
-        or build_mode_env.get("HOLOSCAN_CLI_BUILD_LOCAL")
-    )
+    is_local_mode = is_local_build_requested(args.local, build_mode_env)
 
     if is_local_mode:
         # Build and install locally

--- a/src/holoscan_cli/commands/install.py
+++ b/src/holoscan_cli/commands/install.py
@@ -26,7 +26,7 @@ from holoscan_cli.utils.docker import get_entrypoint_command_args
 from holoscan_cli.utils.holohub import (
     build_holohub_path_mapping,
     check_skip_builds,
-    is_local_build_requested,
+    is_env_request_local_build,
     update_env,
 )
 from holoscan_cli.utils.io import Color, fatal, run_command
@@ -139,7 +139,7 @@ def handle_install(cli, args: argparse.Namespace) -> None:
     update_env(build_mode_env, mode_config.get("build", {}).get("env", {}))
 
     # Check if local mode is requested
-    is_local_mode = is_local_build_requested(args.local, build_mode_env)
+    is_local_mode = args.local or is_env_request_local_build(build_mode_env)
 
     if is_local_mode:
         # Build and install locally

--- a/src/holoscan_cli/commands/package.py
+++ b/src/holoscan_cli/commands/package.py
@@ -31,7 +31,7 @@ from holoscan_cli.utils.docker import get_entrypoint_command_args
 from holoscan_cli.utils.holohub import (
     check_skip_builds,
     get_buildtype_str,
-    is_local_build_requested,
+    is_env_request_local_build,
 )
 from holoscan_cli.utils.io import Color, fatal, run_command, warn
 
@@ -131,7 +131,7 @@ def handle_package(cli, args: argparse.Namespace) -> None:
     """Configure a Holoscan Module and build package artifacts."""
     from holoscan_cli.cli import in_container_cli_command
 
-    is_local_mode = is_local_build_requested(args.local)
+    is_local_mode = args.local or is_env_request_local_build()
 
     if is_local_mode:
         project_data = _resolve_module_project(

--- a/src/holoscan_cli/commands/package.py
+++ b/src/holoscan_cli/commands/package.py
@@ -28,7 +28,11 @@ from typing import Optional
 
 from holoscan_cli.commands.registry import help_for
 from holoscan_cli.utils.docker import get_entrypoint_command_args
-from holoscan_cli.utils.holohub import check_skip_builds, get_buildtype_str
+from holoscan_cli.utils.holohub import (
+    check_skip_builds,
+    get_buildtype_str,
+    is_local_build_requested,
+)
 from holoscan_cli.utils.io import Color, fatal, run_command, warn
 
 
@@ -127,7 +131,7 @@ def handle_package(cli, args: argparse.Namespace) -> None:
     """Configure a Holoscan Module and build package artifacts."""
     from holoscan_cli.cli import in_container_cli_command
 
-    is_local_mode = args.local or os.environ.get("HOLOSCAN_CLI_BUILD_LOCAL")
+    is_local_mode = is_local_build_requested(args.local)
 
     if is_local_mode:
         project_data = _resolve_module_project(

--- a/src/holoscan_cli/commands/run.py
+++ b/src/holoscan_cli/commands/run.py
@@ -28,6 +28,7 @@ from holoscan_cli.utils.docker import get_entrypoint_command_args
 from holoscan_cli.utils.holohub import (
     build_holohub_path_mapping,
     check_skip_builds,
+    is_local_build_requested,
     replace_placeholders,
     update_env,
 )
@@ -173,12 +174,7 @@ def handle_run(cli, args: argparse.Namespace) -> None:
     skip_docker_build, skip_local_build = check_skip_builds(args)
 
     # Check if local mode is requested
-    is_local_mode = (
-        args.local
-        or os.environ.get("HOLOSCAN_CLI_BUILD_LOCAL")
-        or build_mode_env.get("HOLOSCAN_CLI_BUILD_LOCAL")
-        or run_mode_env.get("HOLOSCAN_CLI_BUILD_LOCAL")
-    )
+    is_local_mode = is_local_build_requested(args.local, build_mode_env, run_mode_env)
 
     # Apply mode-specific build configuration for build process
     build_args = cli.get_effective_build_config(args, mode_config)

--- a/src/holoscan_cli/commands/run.py
+++ b/src/holoscan_cli/commands/run.py
@@ -28,7 +28,7 @@ from holoscan_cli.utils.docker import get_entrypoint_command_args
 from holoscan_cli.utils.holohub import (
     build_holohub_path_mapping,
     check_skip_builds,
-    is_local_build_requested,
+    is_env_request_local_build,
     replace_placeholders,
     update_env,
 )
@@ -174,7 +174,7 @@ def handle_run(cli, args: argparse.Namespace) -> None:
     skip_docker_build, skip_local_build = check_skip_builds(args)
 
     # Check if local mode is requested
-    is_local_mode = is_local_build_requested(args.local, build_mode_env, run_mode_env)
+    is_local_mode = args.local or is_env_request_local_build(build_mode_env, run_mode_env)
 
     # Apply mode-specific build configuration for build process
     build_args = cli.get_effective_build_config(args, mode_config)

--- a/src/holoscan_cli/commands/test_cmd.py
+++ b/src/holoscan_cli/commands/test_cmd.py
@@ -25,7 +25,11 @@ import os
 
 from holoscan_cli.commands.registry import help_for
 from holoscan_cli.metadata.utils import normalize_language
-from holoscan_cli.utils.holohub import check_skip_builds, determine_project_prefix
+from holoscan_cli.utils.holohub import (
+    check_skip_builds,
+    determine_project_prefix,
+    is_local_build_requested,
+)
 from holoscan_cli.utils.io import format_cmd, run_command
 
 
@@ -122,7 +126,7 @@ def handle_test(cli, args: argparse.Namespace) -> None:
     container.dryrun = args.dryrun
     container.verbose = args.verbose
 
-    is_local_mode = bool(args.local or os.environ.get("HOLOSCAN_CLI_BUILD_LOCAL"))
+    is_local_mode = is_local_build_requested(args.local)
 
     if not is_local_mode and not skip_docker_build:
         build_args = args.build_args or ""

--- a/src/holoscan_cli/commands/test_cmd.py
+++ b/src/holoscan_cli/commands/test_cmd.py
@@ -28,7 +28,7 @@ from holoscan_cli.metadata.utils import normalize_language
 from holoscan_cli.utils.holohub import (
     check_skip_builds,
     determine_project_prefix,
-    is_local_build_requested,
+    is_env_request_local_build,
 )
 from holoscan_cli.utils.io import format_cmd, run_command
 
@@ -126,7 +126,7 @@ def handle_test(cli, args: argparse.Namespace) -> None:
     container.dryrun = args.dryrun
     container.verbose = args.verbose
 
-    is_local_mode = is_local_build_requested(args.local)
+    is_local_mode = args.local or is_env_request_local_build()
 
     if not is_local_mode and not skip_docker_build:
         build_args = args.build_args or ""

--- a/src/holoscan_cli/utils/holohub.py
+++ b/src/holoscan_cli/utils/holohub.py
@@ -75,12 +75,10 @@ def check_skip_builds(args) -> Tuple[bool, bool]:
     return skip_docker_build, skip_local_build
 
 
-def is_local_build_requested(local: bool, *mode_envs: Mapping[str, str]) -> bool:
-    """Return whether local execution was selected by CLI or environment."""
+def is_env_request_local_build(*mode_envs: Mapping[str, str]) -> bool:
+    """Return whether local execution was selected by the environment."""
     environments = (os.environ, *mode_envs)
-    return local or any(
-        is_env_flag_true(env.get("HOLOSCAN_CLI_BUILD_LOCAL")) for env in environments
-    )
+    return any(is_env_flag_true(env.get("HOLOSCAN_CLI_BUILD_LOCAL")) for env in environments)
 
 
 def _get_holohub_root() -> Path:

--- a/src/holoscan_cli/utils/holohub.py
+++ b/src/holoscan_cli/utils/holohub.py
@@ -31,10 +31,10 @@ import grp
 import os
 import re
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Mapping, Optional, Tuple
 
 from holoscan_cli.utils.io import format_cmd, info, run_info_command, warn
-from holoscan_cli.utils.text import _slugify, get_env_bool
+from holoscan_cli.utils.text import _slugify, get_env_bool, is_env_flag_true
 
 DEFAULT_GIT_REF = "latest"
 
@@ -73,6 +73,14 @@ def check_skip_builds(args) -> Tuple[bool, bool]:
         if getattr(args, "no_docker_build", False):
             info("Skipping container build due to --no-docker-build")
     return skip_docker_build, skip_local_build
+
+
+def is_local_build_requested(local: bool, *mode_envs: Mapping[str, str]) -> bool:
+    """Return whether local execution was selected by CLI or environment."""
+    environments = (os.environ, *mode_envs)
+    return local or any(
+        is_env_flag_true(env.get("HOLOSCAN_CLI_BUILD_LOCAL")) for env in environments
+    )
 
 
 def _get_holohub_root() -> Path:

--- a/src/holoscan_cli/utils/text.py
+++ b/src/holoscan_cli/utils/text.py
@@ -81,10 +81,19 @@ def levenshtein_distance(s1: str, s2: str) -> int:
 # ---- env / CLI arg helpers ---------------------------------------------------
 
 
+_FALSE_ENV_VALUES: Tuple[str, ...] = ("false", "no", "n", "0", "f", "off")
+
+
+def is_env_flag_true(value: Optional[str]) -> bool:
+    """Return whether an optional environment flag is enabled."""
+    normalized = (value or "").strip().lower()
+    return bool(normalized) and normalized not in _FALSE_ENV_VALUES
+
+
 def get_env_bool(
     env_var_name: str,
     default: bool = True,
-    false_values: Tuple[str, ...] = ("false", "no", "n", "0", "f"),
+    false_values: Tuple[str, ...] = _FALSE_ENV_VALUES,
 ) -> Tuple[str, bool]:
     """Check environment variable as boolean flag"""
     env_value = os.environ.get(env_var_name, str(default).lower())

--- a/tests/unit/test_package_cmd.py
+++ b/tests/unit/test_package_cmd.py
@@ -105,12 +105,13 @@ def test_package_deb_emits_pkg_flag_for_standalone_module(tmp_path, monkeypatch)
 
 def test_package_container_honors_no_docker_build_and_cuda(tmp_path, monkeypatch):
     """Container packaging skips the build for --no-docker-build and forwards
-    --cuda to the container build args (holohub#1596, #1597)."""
+    --cuda to the container build args (holohub#1596, #1597). A false local-build
+    env flag must still select this container path."""
     from unittest.mock import MagicMock
 
     import holoscan_cli.cli as cli_mod
 
-    monkeypatch.delenv("HOLOSCAN_CLI_BUILD_LOCAL", raising=False)
+    monkeypatch.setenv("HOLOSCAN_CLI_BUILD_LOCAL", "0")
     monkeypatch.setenv("HOLOSCAN_CLI_ALWAYS_BUILD", "1")
 
     project_data = {


### PR DESCRIPTION
## Problem

Several commands decided local vs. container execution using a bare Python truthiness check:

```python
args.local or os.environ.get("HOLOSCAN_CLI_BUILD_LOCAL")
```

Because any non-empty string is truthy in Python, values like `0`, `false`, and `no` were treated as **True**. A user (or AI agent) who set `HOLOSCAN_CLI_BUILD_LOCAL=0` to explicitly request *container* execution would silently receive a *host* build instead.

### Affected commands
`build`, `run`, `install`, `package`, `test`

## Fix

- Add `is_env_flag_true()` in `utils/text.py` — interprets a raw env/config value against the shared false-value set (`false`, `no`, `n`, `0`, `f`, `off`; blank/`None` is false) instead of relying on string truthiness. `off` is folded into `_FALSE_ENV_VALUES` so `get_env_bool` callers stay consistent.
- Add `is_local_build_requested()` in `utils/holohub.py` — applies the parser uniformly across the `--local` CLI flag, the process environment, and any mode-config `env` mappings (variadic, so `run` can also pass its run-mode env).
- Use the helper in all five affected commands.

## Tests

- Regression coverage in `test_package_cmd.py`: `HOLOSCAN_CLI_BUILD_LOCAL=0` now correctly selects the container path.
- Full unit suite passes (`406 passed, 1 skipped`); `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved, consistent “local vs container” behavior across build, install, package, run, and test commands.
  * Environment-driven local-build flags now consistently treat additional false-like values (e.g., `0` and `off`) as disabled, ensuring container workflows when explicitly turned off.

* **Tests**
  * Updated packaging test setup to set the local-build environment flag to a false value and verify the container packaging path is still used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->