### PR TITLE
fix: honor explicit package projects and require CPack config

### DIFF
--- a/src/holoscan_cli/commands/package.py
+++ b/src/holoscan_cli/commands/package.py
@@ -29,7 +29,7 @@ from typing import Optional
 from holoscan_cli.commands.registry import help_for
 from holoscan_cli.utils.docker import get_entrypoint_command_args
 from holoscan_cli.utils.holohub import check_skip_builds, get_buildtype_str
-from holoscan_cli.utils.io import Color, fatal, run_command, warn
+from holoscan_cli.utils.io import Color, fatal, run_command
 
 
 def register_package_parser(
@@ -81,7 +81,7 @@ def _normalize_module_name(value: str) -> str:
 
 
 def _resolve_module_project(cli, project_arg: Optional[str], language: Optional[str]) -> dict:
-    """Resolve a module from cwd metadata or from the active source tree."""
+    """Resolve a module from matching cwd metadata or the active source tree."""
     cwd = Path.cwd()
     cwd_meta = cwd / "metadata.json"
     if cwd_meta.exists():
@@ -92,20 +92,16 @@ def _resolve_module_project(cli, project_arg: Optional[str], language: Optional[
         if isinstance(data, dict) and "module" in data:
             module = data["module"]
             module_name = module.get("name", cwd.name)
-            if project_arg and _normalize_module_name(project_arg) not in {
+            if project_arg is None or _normalize_module_name(project_arg) in {
                 _normalize_module_name(module_name),
                 _normalize_module_name(cwd.name),
             }:
-                warn(
-                    f"Packaging module '{module_name}' from {cwd}; "
-                    f"ignoring project argument '{project_arg}'."
-                )
-            return {
-                "project_type": "module",
-                "project_name": module_name,
-                "source_folder": str(cwd),
-                "metadata": module,
-            }
+                return {
+                    "project_type": "module",
+                    "project_name": module_name,
+                    "source_folder": str(cwd),
+                    "metadata": module,
+                }
 
     if project_arg:
         project_data = cli.find_project(project_arg, language=language)
@@ -252,13 +248,14 @@ def _package_locally(cli, args: argparse.Namespace, project_data: dict) -> None:
         run_command(build_cmd, dry_run=dryrun, env=build_env)
 
         pkg_config_dir = build_dir / "pkg"
-        cpack_configs = (
-            list(pkg_config_dir.glob("CPackConfig-*.cmake")) if pkg_config_dir.exists() else []
-        )
-        if not cpack_configs and dryrun:
-            bare = project_name.replace("_", "-")
-            if bare.startswith("holoscan-"):
-                bare = bare[len("holoscan-") :]
+        cpack_configs = list(pkg_config_dir.glob("CPackConfig-*.cmake"))
+        if not cpack_configs:
+            if not dryrun:
+                fatal(
+                    f"Packaging '{project_name}' did not generate a CPack configuration. "
+                    "Check that the module defines a package target."
+                )
+            bare = project_name.replace("_", "-").removeprefix("holoscan-")
             cpack_configs = [pkg_config_dir / f"CPackConfig-holoscan-{bare}.cmake"]
         for cpack_config in cpack_configs:
             for generator in cpack_generators:

--- a/tests/unit/test_package_cmd.py
+++ b/tests/unit/test_package_cmd.py
@@ -191,26 +191,38 @@ def test_package_rejects_non_module_project(tmp_path):
         package_cmd.handle_package(cli, _args(project="gst_to_holo"))
 
 
-def test_resolve_module_project_prefers_standalone_cwd_metadata(tmp_path, monkeypatch):
+def test_resolve_module_project_respects_explicit_project(tmp_path, monkeypatch):
     module_dir = tmp_path / "external-module"
     module_dir.mkdir()
     (module_dir / "metadata.json").write_text(
         json.dumps({"module": {"name": "holoscan-smoke", "language": ["Python"]}}),
         encoding="utf-8",
     )
-    cli = _cli(tmp_path)
+    requested_module = {
+        "project_name": "different-name",
+        "project_type": "module",
+        "source_folder": tmp_path / "repo" / "modules" / "different-name",
+        "metadata": {"language": ["Python"]},
+    }
+    cli = _cli(tmp_path, requested_module)
     monkeypatch.chdir(module_dir)
 
-    project_data = package_cmd._resolve_module_project(
+    cwd_project = package_cmd._resolve_module_project(cli, project_arg=None, language=None)
+    matching_project = package_cmd._resolve_module_project(
+        cli, project_arg="holoscan-smoke", language=None
+    )
+    explicit_project = package_cmd._resolve_module_project(
         cli, project_arg="different-name", language=None
     )
 
-    assert project_data == {
+    assert cwd_project == {
         "project_type": "module",
         "project_name": "holoscan-smoke",
         "source_folder": str(module_dir),
         "metadata": {"name": "holoscan-smoke", "language": ["Python"]},
     }
+    assert matching_project == cwd_project
+    assert explicit_project == requested_module
 
 
 def test_resolve_module_project_falls_back_to_source_tree_when_cwd_metadata_invalid(
@@ -233,3 +245,15 @@ def test_resolve_module_project_falls_back_to_source_tree_when_cwd_metadata_inva
     )
 
     assert project_data["project_name"] == "test-module-fixture"
+
+
+def test_package_local_deb_fails_without_cpack_config(wheel_module, monkeypatch):
+    monkeypatch.setattr(package_cmd, "run_command", lambda *a, **k: None)
+    monkeypatch.setattr(package_cmd.shutil, "which", lambda _: None)
+
+    with pytest.raises(SystemExit):
+        package_cmd._package_locally(
+            wheel_module,
+            _args(dryrun=False, pkg_generator="DEB"),
+            wheel_module.find_project("test-module-fixture"),
+        )

--- a/tests/unit/test_package_cmd.py
+++ b/tests/unit/test_package_cmd.py
@@ -247,13 +247,16 @@ def test_resolve_module_project_falls_back_to_source_tree_when_cwd_metadata_inva
     assert project_data["project_name"] == "test-module-fixture"
 
 
-def test_package_local_deb_fails_without_cpack_config(wheel_module, monkeypatch):
+def test_package_local_deb_fails_without_cpack_config(wheel_module, monkeypatch, capsys):
     monkeypatch.setattr(package_cmd, "run_command", lambda *a, **k: None)
     monkeypatch.setattr(package_cmd.shutil, "which", lambda _: None)
 
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit) as exc_info:
         package_cmd._package_locally(
             wheel_module,
             _args(dryrun=False, pkg_generator="DEB"),
             wheel_module.find_project("test-module-fixture"),
         )
+
+    assert exc_info.value.code == 1
+    assert "did not generate a CPack configuration" in capsys.readouterr().err


### PR DESCRIPTION
## Problem

`package` had two user-visible failure modes.

1. An explicit project could be ignored when the current directory contained another module's metadata:

   ```bash
   cd modules/module-a
   /path/to/holohub/holohub package module-b
   ```

   The command used `module-a` from the current directory and ignored the requested `module-b`.

2. A package command could report success without producing a package:

   ```bash
   ./holohub package module-b --pkg-generator DEB
   ```

   If CMake generated no `CPackConfig-*.cmake`, no `cpack` command ran, but the CLI still exited successfully.

## Fix

- Use current-directory metadata only when no project is requested or it matches the requested project.
- Fail clearly when a real CPack build generates no CPack configuration.
- Add unit coverage for both cases.

## Testing

`PYTHONPATH=src pytest -q -o addopts='' tests/unit` (407 passed, 1 skipped)

AI-assisted: Created with Codex/GPT at the user's request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved module project selection when packaging, ensuring explicitly specified projects are handled correctly.
  - Packaging now reports a clear failure when required CPack configuration cannot be generated.
  - Dry-run packaging continues using a default configuration when no generated configuration is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->