### PR TITLE
fix: keep dry runs read-only

### DIFF
--- a/src/holoscan_cli/commands/build.py
+++ b/src/holoscan_cli/commands/build.py
@@ -261,7 +261,8 @@ def build_project_locally(
 
     build_type = get_buildtype_str(build_type)
     build_dir = cli.DEFAULT_BUILD_PARENT_DIR / project_name
-    build_dir.mkdir(parents=True, exist_ok=True)
+    if not dryrun:
+        build_dir.mkdir(parents=True, exist_ok=True)
 
     # Prepare environment with extra env vars first so that HOLOSCAN_CLI_LOCAL_*
     # overrides from the mode's env block are visible to the module resolvers.
@@ -407,13 +408,15 @@ def build_project_locally(
     # Print sccache stats
     if enable_sccache:
         stats_file = build_dir / "sccache-stats.txt"
-        with open(stats_file, "w", encoding="utf-8") as f:
-            run_command(
-                ["sccache", "--show-stats"],
-                dry_run=dryrun,
-                env=build_env,
-                stdout=f if not dryrun else None,
-            )
+        if dryrun:
+            run_command(["sccache", "--show-stats"], dry_run=True, env=build_env)
+        else:
+            with open(stats_file, "w", encoding="utf-8") as f:
+                run_command(
+                    ["sccache", "--show-stats"],
+                    env=build_env,
+                    stdout=f,
+                )
         try:
             stats_file_rel = stats_file.relative_to(cli.HOLOHUB_ROOT)
         except ValueError:

--- a/src/holoscan_cli/commands/package.py
+++ b/src/holoscan_cli/commands/package.py
@@ -216,7 +216,8 @@ def _package_locally(cli, args: argparse.Namespace, project_data: dict) -> None:
 
     if cpack_generators:
         build_dir = cli.DEFAULT_BUILD_PARENT_DIR / package_slug / "package"
-        build_dir.mkdir(parents=True, exist_ok=True)
+        if not dryrun:
+            build_dir.mkdir(parents=True, exist_ok=True)
         cmake_args = [
             "cmake",
             "-B",

--- a/src/holoscan_cli/container/core.py
+++ b/src/holoscan_cli/container/core.py
@@ -721,7 +721,9 @@ class HoloscanContainer:
             sccache_host_dir = get_sccache_dir()
             info(f"Host SCCACHE_DIR: {sccache_host_dir}")
             info(f"Container mount point: {SCCACHE_CONTAINER_DIR}")
-            os.makedirs(sccache_host_dir, exist_ok=True)  # Pre-create for the current user to own
+            if not self.dryrun:
+                # Pre-create for the current user to own.
+                os.makedirs(sccache_host_dir, exist_ok=True)
             args.extend(["-v", f"{sccache_host_dir}:{SCCACHE_CONTAINER_DIR}"])
         elif has_host_sccache_env:
             warn(

--- a/tests/unit/test_container_core.py
+++ b/tests/unit/test_container_core.py
@@ -761,3 +761,17 @@ def test_default_docker_run_args_env_propagates_to_docker_run(tmp_path, monkeypa
 
     cmd = calls[0]
     assert "TEST_ENV=123" in cmd
+
+
+@pytest.mark.parametrize("dryrun", [True, False])
+def test_get_volume_args_only_creates_sccache_dir_for_real_run(tmp_path, monkeypatch, dryrun):
+    sccache_dir = tmp_path / "sccache-cache"
+    monkeypatch.setenv("HOLOSCAN_CLI_ENABLE_SCCACHE", "true")
+    monkeypatch.setenv("SCCACHE_DIR", str(sccache_dir))
+
+    c = _stub_container(tmp_path)
+    c.dryrun = dryrun
+    args = c.get_volume_args(add_volumes=[], enable_mps=False)
+
+    assert sccache_dir.exists() == (not dryrun)
+    assert f"{sccache_dir}:{container_core.SCCACHE_CONTAINER_DIR}" in args

--- a/tests/unit/test_lifecycle_commands.py
+++ b/tests/unit/test_lifecycle_commands.py
@@ -222,6 +222,7 @@ def test_build_project_locally_emits_application_cmake_and_build_commands(tmp_pa
 
     cmake_args = " ".join(str(part) for part in calls[0])
     assert build_dir == tmp_path / "build" / "smoke_app"
+    assert not build_dir.exists()
     assert project_data is cli.project_data
     assert "-DAPP_smoke_app=ON" in cmake_args
     assert "-DCMAKE_BUILD_TYPE=Debug" in cmake_args
@@ -247,6 +248,9 @@ def test_build_project_locally_module_enables_subprojects_and_sccache(
         },
     }
     cli = RecordingCLI(tmp_path, project)
+    stats_file = cli.DEFAULT_BUILD_PARENT_DIR / "holoscan-smoke" / "sccache-stats.txt"
+    stats_file.parent.mkdir(parents=True)
+    stats_file.write_text("existing stats", encoding="utf-8")
     calls = []
     monkeypatch.setenv("HOLOSCAN_CLI_ENABLE_SCCACHE", "true")
     monkeypatch.setattr(build_cmd, "run_command", lambda cmd, **kwargs: calls.append(cmd))
@@ -254,7 +258,9 @@ def test_build_project_locally_module_enables_subprojects_and_sccache(
         build_cmd.shutil, "which", lambda name: "/usr/bin/sccache" if name == "sccache" else None
     )
 
-    build_cmd.build_project_locally(cli, "holoscan-smoke", language="cpp", dryrun=True)
+    build_dir, _ = build_cmd.build_project_locally(
+        cli, "holoscan-smoke", language="cpp", dryrun=True
+    )
 
     cmake_args = " ".join(str(part) for part in calls[0])
     assert "-DMODULE_holoscan_smoke=ON" in cmake_args
@@ -262,6 +268,8 @@ def test_build_project_locally_module_enables_subprojects_and_sccache(
     assert "-DAPP_smoke_app=ON" in cmake_args
     assert "-DCMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/sccache" in cmake_args
     assert calls[-1] == ["sccache", "--show-stats"]
+    assert build_dir == stats_file.parent
+    assert stats_file.read_text(encoding="utf-8") == "existing stats"
     assert "Building module 'holoscan-smoke'" in capsys.readouterr().out
 
 

--- a/tests/unit/test_package_cmd.py
+++ b/tests/unit/test_package_cmd.py
@@ -78,6 +78,7 @@ def test_package_deb_emits_module_cmake_flag_for_in_tree_module(tmp_path, monkey
     assert "-DPKG_test_module_fixture=ON" in cmake_args
     assert "-DBUILD_ALL=OFF" in cmake_args
     assert calls[2][0] == "cpack"
+    assert not (cli.DEFAULT_BUILD_PARENT_DIR / "test_module_fixture" / "package").exists()
 
 
 def test_package_deb_emits_pkg_flag_for_standalone_module(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- Keep build, package, and container sccache setup read-only during `--dryrun`.
- Preserve command previews without creating directories or truncating sccache stats.

## Testing

- Unit tests: 408 passed, 1 skipped
- Ruff on changed files

AI-assisted: Created with Codex/GPT at the user's request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dry-run builds and packaging no longer create build directories or modify cache statistics files.
  * Dry-run container setup no longer creates local SCCache directories.
  * SCCache volume mappings continue to be prepared correctly without unwanted filesystem changes.

* **Tests**
  * Added coverage verifying dry-run operations leave build, package, and statistics files unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->