### PR TITLE
Fix Ctrl+C handling when running applications

### DIFF
--- a/src/holoscan_cli/__main__.py
+++ b/src/holoscan_cli/__main__.py
@@ -204,7 +204,7 @@ def _dispatch_project_cli(argv: list[str]) -> bool:
     return True
 
 
-def main(argv: Optional[list[str]] = None):
+def _dispatch(argv: Optional[list[str]]) -> None:
     if argv is None:
         argv = sys.argv
     argv = list(argv)
@@ -222,6 +222,15 @@ def main(argv: Optional[list[str]] = None):
         from .version.version import execute_version_command
 
         execute_version_command(args)
+
+
+def main(argv: Optional[list[str]] = None):
+    try:
+        _dispatch(argv)
+    except KeyboardInterrupt:
+        # The CLI owns pre-launch work. After launch, exec removes this frame
+        # and the application retains control of its signal handling and status.
+        raise SystemExit(130) from None
 
 
 if __name__ == "__main__":

--- a/src/holoscan_cli/commands/run.py
+++ b/src/holoscan_cli/commands/run.py
@@ -321,12 +321,15 @@ def handle_run(cli, args: argparse.Namespace) -> None:
             *(name for name in run_env if name.startswith("HOLOSCAN_")),
             *run_mode_env,
         }
+        # Nothing follows the foreground launch, so hand this process over to
+        # the application instead of remaining as a signal-handling supervisor.
         run_command(
             cmd_to_run,
             env=run_env,
             dry_run=args.dryrun,
             as_root=as_root,
             preserve_env=root_env if as_root else None,
+            replace_process=True,
         )
     else:
         container = cli.make_project_container(
@@ -414,7 +417,9 @@ def handle_run(cli, args: argparse.Namespace) -> None:
             local_sdk_root=getattr(args, "local_sdk_root", None),
             enable_x11=getattr(args, "enable_x11", True),
             ssh_x11=getattr(args, "ssh_x11", False),
-            use_tini=getattr(args, "init", False),
+            # Keep the exec'd application out of the PID-namespace init slot,
+            # where default-disposition signals have special semantics.
+            use_tini=True,
             persistent=getattr(args, "persistent", False),
             nsys_profile=getattr(args, "nsys_profile", False),
             nsys_location=getattr(args, "nsys_location", ""),

--- a/src/holoscan_cli/container/core.py
+++ b/src/holoscan_cli/container/core.py
@@ -653,7 +653,11 @@ class HoloscanContainer:
             try:
                 try:
                     with _ContainerTerminationHandler():
-                        run_command(cmd)
+                        result = run_command(cmd, check=False)
+                    if result.returncode:
+                        # Docker and the application already wrote their diagnostics.
+                        # Preserve the status without repeating the full launch command.
+                        sys.exit(result.returncode)
                     return
                 except _ContainerTerminationSignal as exc:
                     sig = exc.signum

--- a/src/holoscan_cli/utils/io.py
+++ b/src/holoscan_cli/utils/io.py
@@ -20,12 +20,13 @@ subprocess execution."""
 import os
 import shlex
 import shutil
+import signal
 import subprocess
 import sys
 import traceback
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable, List, Optional, Union
+from typing import Iterable, List, Mapping, NoReturn, Optional, Union
 
 
 def resolve(path) -> Path:
@@ -202,12 +203,31 @@ def format_long_command(cmd: List[str], max_line_length: int = 80) -> str:
 # ---- subprocess execution + explicit privilege elevation ---------------------
 
 
+# exec preserves ignored signals. Reset the signals Python normally restores
+# when starting a child process.
+_RESTORE_SIGNAL_NAMES = ("SIGPIPE", "SIGXFZ", "SIGXFSZ")
+
+
+def _replace_process(argv: List[str], env: Mapping[str, str]) -> NoReturn:
+    """Replace this process with ``argv``. Only raises if ``exec`` fails."""
+    sys.stdout.flush()
+    sys.stderr.flush()
+
+    for name in _RESTORE_SIGNAL_NAMES:
+        signum = getattr(signal, name, None)
+        if signum is not None:
+            signal.signal(signum, signal.SIG_DFL)
+
+    os.execvpe(argv[0], argv, env)
+
+
 def run_command(
     cmd: Union[str, List[str]],
     dry_run: bool = False,
     check: bool = True,
     as_root: bool = False,
     preserve_env: Optional[Iterable[str]] = None,
+    replace_process: bool = False,
     **kwargs,
 ) -> subprocess.CompletedProcess:
     """Run a command, optionally elevated with ``sudo``.
@@ -220,9 +240,19 @@ def run_command(
     names go through ``--preserve-env`` so their values — possibly secrets —
     stay out of the world-readable /proc/<pid>/cmdline. Missing sudo fails
     clearly rather than running unprivileged.
+
+    ``replace_process`` is only for the final foreground application. It uses
+    ``exec`` so the Python CLI cannot also receive terminal signals or overwrite
+    the application's status. Do not use it for builds or the host Docker
+    launch, where the caller must continue for cleanup. A dry run only prints.
     """
     if preserve_env is not None and not as_root:
         raise ValueError("preserve_env requires as_root=True")
+    if replace_process:
+        if isinstance(cmd, str):
+            raise ValueError("replace_process requires an argv list, not a shell command string")
+        if kwargs.get("env") is None:
+            raise ValueError("replace_process requires an explicit environment")
 
     elevate = as_root and os.geteuid() != 0
     sudo_prefix: List[str] = []
@@ -284,6 +314,8 @@ def run_command(
         return subprocess.CompletedProcess(exec_cmd, 0)
 
     print(format_cmd(display_cmd))
+    if replace_process:
+        _replace_process(exec_cmd, kwargs["env"])
     try:
         return subprocess.run(exec_cmd, check=check, **kwargs)
     except subprocess.CalledProcessError as e:

--- a/tests/unit/test_cli_behaviors.py
+++ b/tests/unit/test_cli_behaviors.py
@@ -13,6 +13,7 @@ import pytest
 
 from holoscan_cli import cli as project_cli
 from holoscan_cli.commands import clear_cache as clear_cache_cmd
+from holoscan_cli.commands import run as run_cmd
 
 FIXTURE_ROOT = Path(__file__).resolve().parent.parent / "fixtures" / "holohub_smoke"
 
@@ -26,6 +27,16 @@ def _copy_smoke_repo(tmp_path: Path) -> Path:
 def test_cli_dispatch_runs_smoke_app_locally_from_metadata(tmp_path, monkeypatch, capfd):
     if shutil.which("python") is None:
         pytest.skip("the smoke fixture command requires a python executable on PATH")
+
+    original_run_command = run_cmd.run_command
+
+    def run_without_replacement(cmd, **kwargs):
+        # Keep this existing metadata smoke in-process. The real exec boundary
+        # is covered by the external signal test.
+        kwargs["replace_process"] = False
+        return original_run_command(cmd, **kwargs)
+
+    monkeypatch.setattr(run_cmd, "run_command", run_without_replacement)
 
     repo_root = _copy_smoke_repo(tmp_path)
     build_parent = tmp_path / "build"

--- a/tests/unit/test_container_core.py
+++ b/tests/unit/test_container_core.py
@@ -27,6 +27,7 @@ These pin two pieces of the container layer that were uncovered:
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -556,7 +557,12 @@ def test_run_assembles_docker_command_without_ctk_for_custom_runtime(tmp_path, m
     monkeypatch.setenv("NGC_CLI_API_KEY", "secret")
     monkeypatch.setattr(container_core, "get_image_pythonpath", lambda img, dryrun: "/image/python")
     monkeypatch.setattr(container_core, "get_group_id", lambda group: {"video": 44}.get(group))
-    monkeypatch.setattr(container_core, "run_command", lambda cmd, **kwargs: calls.append(cmd))
+
+    def record_command(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(container_core, "run_command", record_command)
     monkeypatch.setattr(container_core, "check_nvidia_ctk", lambda: ctk_checks.append(True))
 
     c = _stub_container(


### PR DESCRIPTION
## What changed

- let applications handle Ctrl+C directly after they start
- use Docker's small init helper for application containers
- exit with status 130 without a traceback when Ctrl+C interrupts setup or build work
- preserve application exit codes without repeating the long Docker command

## Why

Previously, both the CLI and application could react to Ctrl+C. The CLI could
stop first, print a traceback, cut application cleanup short, and replace the
application's exit code.

Now the CLI hands over control after launching the application. The application
can finish its cleanup and return its chosen exit code.

## Testing

- 416 unit tests passed, 1 skipped
- verified a slow Ctrl+C handler completes and returns status 42
- verified Ctrl+C during CLI-owned work returns 130 without a traceback
- verified failed application launches still report an error

AI-assisted: Created with Codex/GPT at the user's request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of keyboard interrupts, returning the standard exit status.
  * Local application runs now hand control directly to the launched application for more reliable signal handling.
  * Container runs consistently use an init process and preserve the application’s original failure status.
  * Improved error handling prevents command failures from being obscured or duplicated in output.

* **Tests**
  * Updated command and container execution coverage to reflect the improved runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->