### PR TITLE
fix: honor --verbose during local builds

### DIFF
--- a/src/holoscan_cli/commands/build.py
+++ b/src/holoscan_cli/commands/build.py
@@ -170,6 +170,7 @@ def handle_build(cli, args: argparse.Namespace) -> None:
             build_type=args.build_type,
             with_operators=build_args.get("with_operators"),
             dryrun=args.dryrun,
+            verbose=args.verbose,
             pkg_generator=getattr(args, "pkg_generator", "DEB"),
             parallel=getattr(args, "parallel", None),
             benchmark=getattr(args, "benchmark", False),
@@ -236,6 +237,7 @@ def build_project_locally(
     build_type: Optional[str] = None,
     with_operators: Optional[str] = None,
     dryrun: bool = False,
+    verbose: bool = False,
     pkg_generator: str = "DEB",
     parallel: Optional[str] = None,
     benchmark: bool = False,
@@ -276,7 +278,7 @@ def build_project_locally(
             prefix=cli.prefix,
             verbose=dryrun,
         )
-        update_env(build_env, extra_env, path_mapping, verbose=dryrun)
+        update_env(build_env, extra_env, path_mapping, verbose=(verbose or dryrun))
 
     # Write external_operators_manifest.cmake before cmake configure so that
     # CMakeLists.txt:include(…OPTIONAL) picks it up and FetchContent_MakeAvailable

--- a/src/holoscan_cli/commands/install.py
+++ b/src/holoscan_cli/commands/install.py
@@ -150,6 +150,7 @@ def handle_install(cli, args: argparse.Namespace) -> None:
             build_type=args.build_type,
             with_operators=build_args.get("with_operators"),
             dryrun=args.dryrun,
+            verbose=args.verbose,
             parallel=getattr(args, "parallel", None),
             configure_args=build_args.get("configure_args"),
             extra_env=build_mode_env,

--- a/src/holoscan_cli/commands/run.py
+++ b/src/holoscan_cli/commands/run.py
@@ -204,6 +204,7 @@ def handle_run(cli, args: argparse.Namespace) -> None:
                 build_type=args.build_type,
                 with_operators=build_args.get("with_operators"),
                 dryrun=args.dryrun,
+                verbose=args.verbose,
                 pkg_generator=getattr(args, "pkg_generator", "DEB"),
                 parallel=getattr(args, "parallel", None),
                 configure_args=build_args.get("configure_args"),

--- a/tests/unit/test_lifecycle_commands.py
+++ b/tests/unit/test_lifecycle_commands.py
@@ -314,6 +314,19 @@ def test_build_writes_external_operators_manifest_from_module_sites(tmp_path, mo
     assert "videomaster_source" in content
 
 
+def test_build_project_locally_verbose_prints_env_mapping(tmp_path, monkeypatch, capsys):
+    """`--verbose` surfaces the resolved env mapping on a non-dryrun local build."""
+    cli = RecordingCLI(tmp_path)
+    monkeypatch.setattr(build_cmd, "run_command", lambda cmd, **kwargs: None)
+    monkeypatch.setattr(build_cmd.shutil, "which", lambda name: None)
+
+    build_cmd.build_project_locally(
+        cli, "smoke_app", dryrun=False, verbose=True, extra_env={"DEMO_VAR": "on"}
+    )
+
+    assert "export DEMO_VAR=on" in capsys.readouterr().out
+
+
 def test_handle_build_container_branch_passes_recursive_local_command(tmp_path, monkeypatch):
     project = {
         "project_name": "smoke_app",


### PR DESCRIPTION
## Problem

`build_project_locally()` — documented at `build.py:18` as the shared helper for local builds — accepted `dryrun` but had no `verbose` parameter. All three callers therefore dropped `--verbose` at that boundary, and the helper's `update_env` call fell back to `verbose=dryrun`, so the resolved environment mapping was never printed for the build phase.

Two visible effects:

- **`holoscan build <proj> --local --verbose` produced no extra output at all.** The flag was accepted, forwarded into container recursion (`build.py:75`) and set on `container.verbose` (`build.py:186`), but was inert on the local path.
- **`holoscan install <proj> --local --verbose` was internally split**: no mapping for the build step it had just run, then a mapping for the install step. Same command, same flag, two behaviors.

`run` was already correct (`run.py:233`), which is what made the divergence easy to miss.

## Change

Add a `verbose` parameter to `build_project_locally()` and use it for the `update_env` call, then pass `args.verbose` from all three callers (`build.py`, `run.py`, `install.py`). This matches the `(args.verbose or args.dryrun)` expression that `run` and `install` already used for their own `update_env` calls.

Two deliberate non-changes:

- **`build_holohub_path_mapping(verbose=dryrun)` is left alone.** All three call sites already agree on dryrun-only for path mapping (`install.py:165`, `run.py:220`), so only the `update_env` call had diverged.
- **Nothing is forwarded to cmake.** `--verbose` still does not become `cmake --build --verbose` or `cmake --install --verbose`. Neither command has ever passed it, so that is a uniform gap rather than an inconsistency, and closing it would change output volume for every user — a separate decision from making the existing flag behave consistently.

## Notes for review

- **This changes output for existing invocations.** Anyone already running `build --local --verbose` will now see env-mapping lines they did not see before. That is the intent, but it is new output in an unchanged command.
- **`verbose` is inserted after `dryrun` rather than appended** to the signature. Safe because every call site — three in `src/`, five in tests — passes these by keyword, but it is a signature change to a shared helper.

## Testing

One test covering the helper honoring `verbose` on a non-dryrun local build. Verified it fails without the source change and passes with it. Full unit suite: 417 passed, 1 skipped. `ruff`, `black`, `isort` and codespell clean on all four changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added verbose output support for local build, install, and run commands.
  * Verbose mode now displays the resolved build environment during local builds.
  * Dry-run builds automatically provide expanded environment details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->