### PR TITLE
feat: add -v/--version as top-level aliases for `holoscan version`

### DIFF
--- a/src/holoscan_cli/__main__.py
+++ b/src/holoscan_cli/__main__.py
@@ -88,6 +88,16 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
         prog=program_name,
     )
 
+    # Top-level alias for the `version` subcommand. Declared on `parser` rather
+    # than `parent_parser` so it does not leak onto every subcommand.
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="store_true",
+        dest="show_version",
+        help="display the holoscan-cli package version",
+    )
+
     subparser = parser.add_subparsers(dest="command")
 
     version_parser = subparser.add_parser(
@@ -112,7 +122,7 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     args.argv = argv  # save argv for later use in runpy
 
     # Print help if no command is specified
-    if args.command is None:
+    if args.command is None and not args.show_version:
         parser.print_help()
         parser.exit()
 
@@ -218,7 +228,7 @@ def _dispatch(argv: Optional[list[str]]) -> None:
 
     set_up_logging(args.log_level)
 
-    if args.command == "version":
+    if args.command == "version" or args.show_version:
         from .version.version import execute_version_command
 
         execute_version_command(args)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -247,6 +247,16 @@ class TestMain:
                     main(["holoscan", "version"])
                     mock_execute.assert_called_once_with(mock_args)
 
+    @pytest.mark.parametrize("flag", ["-v", "--version"])
+    def test_main_version_flag_matches_version_command(self, flag, capsys):
+        """`-v`/`--version` are aliases: identical output to `holoscan version`."""
+        main(["holoscan", "version"])
+        expected = capsys.readouterr().out
+        assert "Version:" in expected
+
+        main(["holoscan", flag])
+        assert capsys.readouterr().out == expected
+
     @pytest.mark.parametrize(
         "argv,command",
         [(["holoscan", command], command) for command in REMOVED_COMMANDS],


### PR DESCRIPTION
## Change

`version` is the only command implemented by `__main__` itself (`registry.py:34`) and is reachable only as a subcommand. This adds `-v` and `--version` as top-level aliases, so all three spellings produce identical output:

```
$ holoscan --version
Package:     holoscan-cli
Version:     0.0.0+local
Executable:  /path/to/holoscan
Module:      /path/to/src/holoscan_cli/version/version.py
```

## Implementation notes

- **Routes to `execute_version_command`, not argparse's `action="version"`.** The built-in action prints a single string and exits, whereas `holoscan version` prints a four-line block (`version.py:48-51`). Calling the real handler keeps the alias byte-identical rather than merely similar.
- **Declared on `parser`, not `parent_parser`.** `parent_parser` is inherited via `parents=` by every subparser (`__main__.py:97`, `__main__.py:108`), so declaring it there would produce `holoscan build --version`, `holoscan version --version`, and so on.
- **The no-subcommand branch needed adjusting.** `holoscan -v` leaves `args.command` as `None`, which previously hit the print-help-and-exit path before dispatch could run.

## Trade-off worth a look

This claims `-v` for version, so it is no longer available as a short form for the `--verbose` flag that every project subcommand carries. Precedent runs both ways — docker and git use `-v` for version; pip and python use `-V` and keep `-v` for verbose. Flagging it because it is a one-way door on a public CLI surface; adding `-V` alongside would cost one line if that is preferred.

Two behaviors that are unchanged and intentional:

- `holoscan build -v` remains an "unrecognized argument" error. `-v` is top-level only, and it was already an error before this change.
- `holoscan --version --json` is not supported, since `--json` lives only on the version subparser (`__main__.py:100`). `execute_version_command` degrades to human-readable output via `getattr(args, "json", False)`, so it fails cleanly rather than crashing. `holoscan version --json` is unaffected.

## Testing

One parametrized test asserting `-v` and `--version` produce output identical to `holoscan version`, which covers parsing, the no-subcommand branch, and dispatch in one pass. Verified it fails without the source change.

Also checked by hand: bare `holoscan` still prints help and exits, and `holoscan build ... -v` still errors as before.

Full unit suite: 418 passed, 1 skipped. `ruff`, `black`, `isort` and codespell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `-v` and `--version` options to display package version information.
  * Improved command-line help behavior when no command or version option is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->